### PR TITLE
Fix: 修复批量解密海量图片时导致的 V8 内存溢出 (OOM) 问题

### DIFF
--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -3485,20 +3485,17 @@ function ChatPage(props: ChatPageProps) {
     }
 
     // 并发池：同时跑 concurrency 个任务
-    const pool: Promise<void>[] = []
+    const pool = new Set<Promise<void>>()
     for (const img of images) {
-      const p = decryptOne(img)
-      pool.push(p)
-      if (pool.length >= concurrency) {
+      const p = decryptOne(img).then(() => { pool.delete(p) })
+      pool.add(p)
+      if (pool.size >= concurrency) {
         await Promise.race(pool)
-        // 移除已完成的
-        for (let j = pool.length - 1; j >= 0; j--) {
-          const settled = await Promise.race([pool[j].then(() => true), Promise.resolve(false)])
-          if (settled) pool.splice(j, 1)
-        }
       }
     }
-    await Promise.all(pool)
+    if (pool.size > 0) {
+      await Promise.all(pool)
+    }
 
     finishDecrypt(successCount, failCount)
   }, [batchImageMessages, batchImageSelectedDates, batchDecryptConcurrency, currentSessionId, finishDecrypt, sessions, startDecrypt, updateDecryptProgress])


### PR DESCRIPTION
你好！感谢提供优秀的微信聊天记录管理工具。本 PR 修复了在执行“批量解密图片”操作时，由于海量任务并发导致的内存溢出问题。

#### 问题现象
在处理大量图片（如 45974 张）的批量解密时，内存占用会迅速增加直到4GB，应用会崩溃退出。控制台抛出 `V8 javascript OOM` 错误，核心日志如下：

```text
[ChatService] 共找到45974条图片消息（去重后）

<--- Last few GCs --->

[30160:00002DEC004F8000]    30308 ms: Scavenge (during sweeping) 3977.5 (4003.4) -> 3973.9 (4004.2) MB, pooled: 0.0 MB, 9.50 / 0.00 ms (average mu = 0.244, current mu = 0.202) allocation failure;
[30160:00002DEC004F8000]    31231 ms: Mark-Compact 3978.6 (4008.2) -> 3974.5 (4008.9) MB, pooled: 0.0 MB, 920.37 / 0.00 ms (average mu = 0.145, current mu = 0.040) allocation failure; scavenge might not succeed

[30160:0311/190602.020:ERROR:third_party\blink\renderer\bindings\core\v8\v8_initializer.cc:855] V8 javascript OOM (Ineffective mark-compacts near heap limit).
[30160:0311/190602.022:ERROR:third_party\crashpad\crashpad\client\crashpad_client_win.cc:869] not connected
```

#### 问题原因
问题出现在 `src/pages/ChatPage.tsx` 中的并发池处理逻辑。
原有逻辑在派发数万级别的 Promise 任务时，未能及时清理已完成任务的引用。这导致大量 Promise 对象及其绑定的闭包上下文（包含体积较大的图像 Buffer）被长期驻留在内存中。由于引用未断开，V8 引擎的垃圾回收器（GC）无法介入回收，堆内存（Heap）随循环不断堆积，最终触发 OOM。

#### 解决思路与修复方式
重构了并发控制逻辑，采用基于 `Set` 的动态任务池来严格控制内存分配与释放：

1. **及时释放引用**：在每个 `decryptOne` 任务的 `.then()` 回调中，立即执行 `pool.delete(p)` **将自身从集合中移除**。断开引用后，GC 即可迅速回收该任务占用的内存。
2. **严格控制并发阈值**：当活跃任务数达到 `concurrency` 上限时，通过 `await Promise.race(pool)` 阻塞主循环，确保同一时刻内存中最多只保留设定数量的执行上下文。
3. **统一收尾**：循环结束后通过 `Promise.all` 清理剩余未完成的任务。

修改后的核心代码片段如下：

```typescript
    // 并发池：同时跑 concurrency 个任务
    const pool = new Set<Promise<void>>()
    for (const img of images) {
      const p = decryptOne(img).then(() => { pool.delete(p) })
      pool.add(p)
      if (pool.size >= concurrency) {
        await Promise.race(pool)
      }
    }
    if (pool.size > 0) {
      await Promise.all(pool)
    }

    finishDecrypt(successCount, failCount)
```

#### 测试结果
经过本地测试，应用此修复后，在一次性处理 45974 张图片的解密任务时，内存占用保持平稳，未再出现 OOM 崩溃，批量解密流程可顺利完成。

请帮忙 Review，谢谢！