### PR TITLE
修复转发聊天记录解析与导出

### DIFF
--- a/electron/services/chatService.ts
+++ b/electron/services/chatService.ts
@@ -113,8 +113,20 @@ export interface Message {
     datatype: number
     sourcename: string
     sourcetime: string
-    datadesc: string
+    sourceheadurl?: string
+    datadesc?: string
     datatitle?: string
+    fileext?: string
+    datasize?: number
+    messageuuid?: string
+    dataurl?: string
+    datathumburl?: string
+    datacdnurl?: string
+    aeskey?: string
+    md5?: string
+    imgheight?: number
+    imgwidth?: number
+    duration?: number
   }>
   _db_path?: string // 内部字段：记录消息所属数据库路径
 }
@@ -277,6 +289,100 @@ class ChatService {
     // 初始化LRU缓存，限制大小防止内存泄漏
     this.voiceWavCache = new LRUCache(this.voiceWavCacheMaxEntries)
     this.voiceTranscriptCache = new LRUCache(1000) // 最多缓存1000条转写记录
+  }
+
+  private parseChatRecordDataItem(body: string, datatype = 0) {
+    const sourcename = this.extractXmlValue(body, 'sourcename')
+    const sourcetime = this.extractXmlValue(body, 'sourcetime')
+    const sourceheadurl = this.extractXmlValue(body, 'sourceheadurl') || undefined
+    const datadesc = this.extractXmlValue(body, 'datadesc')
+    const datatitle = this.extractXmlValue(body, 'datatitle')
+    const fileext = this.extractXmlValue(body, 'fileext') || undefined
+    const datasizeRaw = this.extractXmlValue(body, 'datasize')
+    const messageuuid = this.extractXmlValue(body, 'messageuuid') || undefined
+    const dataurl = this.extractXmlValue(body, 'dataurl')
+    const datathumburl = this.extractXmlValue(body, 'datathumburl') || this.extractXmlValue(body, 'thumburl')
+    const datacdnurl = this.extractXmlValue(body, 'datacdnurl') || this.extractXmlValue(body, 'cdnurl')
+    const aeskey = this.extractXmlValue(body, 'aeskey') || this.extractXmlValue(body, 'qaeskey')
+    const md5 = this.extractXmlValue(body, 'md5') || this.extractXmlValue(body, 'datamd5')
+    const imgheightRaw = this.extractXmlValue(body, 'imgheight')
+    const imgwidthRaw = this.extractXmlValue(body, 'imgwidth')
+    const durationRaw = this.extractXmlValue(body, 'duration')
+
+    const datasize = datasizeRaw ? parseInt(datasizeRaw, 10) : undefined
+    const imgheight = imgheightRaw ? parseInt(imgheightRaw, 10) : undefined
+    const imgwidth = imgwidthRaw ? parseInt(imgwidthRaw, 10) : undefined
+    const duration = durationRaw ? parseInt(durationRaw, 10) : undefined
+
+    return {
+      datatype,
+      sourcename,
+      sourcetime: sourcetime || '',
+      sourceheadurl,
+      datadesc: this.decodeHtmlEntities(datadesc) || undefined,
+      datatitle: this.decodeHtmlEntities(datatitle) || undefined,
+      fileext,
+      datasize: Number.isFinite(datasize) ? datasize : undefined,
+      messageuuid,
+      dataurl: this.decodeHtmlEntities(dataurl) || undefined,
+      datathumburl: this.decodeHtmlEntities(datathumburl) || undefined,
+      datacdnurl: this.decodeHtmlEntities(datacdnurl) || undefined,
+      aeskey: this.decodeHtmlEntities(aeskey) || undefined,
+      md5: md5 || undefined,
+      imgheight: Number.isFinite(imgheight) ? imgheight : undefined,
+      imgwidth: Number.isFinite(imgwidth) ? imgwidth : undefined,
+      duration: Number.isFinite(duration) ? duration : undefined
+    }
+  }
+
+  private parseChatRecordList(content: string): Array<{
+    datatype: number
+    sourcename: string
+    sourcetime: string
+    sourceheadurl?: string
+    datadesc?: string
+    datatitle?: string
+    fileext?: string
+    datasize?: number
+    messageuuid?: string
+    dataurl?: string
+    datathumburl?: string
+    datacdnurl?: string
+    aeskey?: string
+    md5?: string
+    imgheight?: number
+    imgwidth?: number
+    duration?: number
+  }> | undefined {
+    const cdataMatch = /<recorditem>[\s\S]*?<!\[CDATA\[([\s\S]*?)\]\]>[\s\S]*?<\/recorditem>/i.exec(content)
+    if (cdataMatch) {
+      const items: Array<ReturnType<typeof this.parseChatRecordDataItem>> = []
+      const itemRegex = /<dataitem\b([^>]*)>([\s\S]*?)<\/dataitem>/gi
+      let itemMatch: RegExpExecArray | null
+
+      while ((itemMatch = itemRegex.exec(cdataMatch[1])) !== null) {
+        const datatypeAttr = /datatype="(\d+)"/i.exec(itemMatch[1])
+        const datatype = datatypeAttr ? parseInt(datatypeAttr[1], 10) : 0
+        items.push(this.parseChatRecordDataItem(itemMatch[2], datatype))
+      }
+
+      if (items.length > 0) {
+        return items
+      }
+    }
+
+    const legacyItems: Array<ReturnType<typeof this.parseChatRecordDataItem>> = []
+    const recordItemRegex = /<recorditem>([\s\S]*?)<\/recorditem>/gi
+    let match: RegExpExecArray | null
+
+    while ((match = recordItemRegex.exec(content)) !== null) {
+      const itemXml = match[1]
+      const datatypeStr = this.extractXmlValue(itemXml, 'datatype')
+      const datatype = datatypeStr ? parseInt(datatypeStr, 10) : 0
+      legacyItems.push(this.parseChatRecordDataItem(itemXml, datatype))
+    }
+
+    return legacyItems.length > 0 ? legacyItems : undefined
   }
 
   /**
@@ -3950,8 +4056,20 @@ class ChatService {
       datatype: number
       sourcename: string
       sourcetime: string
-      datadesc: string
+      sourceheadurl?: string
+      datadesc?: string
       datatitle?: string
+      fileext?: string
+      datasize?: number
+      messageuuid?: string
+      dataurl?: string
+      datathumburl?: string
+      datacdnurl?: string
+      aeskey?: string
+      md5?: string
+      imgheight?: number
+      imgwidth?: number
+      duration?: number
     }>
   } {
     try {
@@ -4134,43 +4252,7 @@ class ChatService {
         case '19': {
           // 聊天记录
           result.chatRecordTitle = title || '聊天记录'
-
-          // 解析聊天记录列表
-          const recordList: Array<{
-            datatype: number
-            sourcename: string
-            sourcetime: string
-            datadesc: string
-            datatitle?: string
-          }> = []
-
-          // 查找所有 <recorditem> 标签
-          const recordItemRegex = /<recorditem>([\s\S]*?)<\/recorditem>/gi
-          let match: RegExpExecArray | null
-
-          while ((match = recordItemRegex.exec(content)) !== null) {
-            const itemXml = match[1]
-
-            const datatypeStr = this.extractXmlValue(itemXml, 'datatype')
-            const sourcename = this.extractXmlValue(itemXml, 'sourcename')
-            const sourcetime = this.extractXmlValue(itemXml, 'sourcetime')
-            const datadesc = this.extractXmlValue(itemXml, 'datadesc')
-            const datatitle = this.extractXmlValue(itemXml, 'datatitle')
-
-            if (sourcename && datadesc) {
-              recordList.push({
-                datatype: datatypeStr ? parseInt(datatypeStr, 10) : 0,
-                sourcename,
-                sourcetime: sourcetime || '',
-                datadesc,
-                datatitle: datatitle || undefined
-              })
-            }
-          }
-
-          if (recordList.length > 0) {
-            result.chatRecordList = recordList
-          }
+          result.chatRecordList = this.parseChatRecordList(content)
           break
         }
 

--- a/electron/services/exportHtml.css
+++ b/electron/services/exportHtml.css
@@ -197,6 +197,71 @@ body {
   color: #1d4ed8;
 }
 
+.chat-record-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid rgba(79, 70, 229, 0.18);
+  border-radius: 14px;
+  background: rgba(79, 70, 229, 0.05);
+}
+
+.chat-record-card-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.chat-record-card-meta {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.chat-record-card-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.chat-record-item {
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(229, 231, 235, 0.9);
+}
+
+.message.sent .chat-record-item {
+  background: rgba(255, 255, 255, 0.58);
+}
+
+.chat-record-item-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 4px;
+}
+
+.chat-record-item-sender {
+  font-size: 12px;
+  font-weight: 600;
+  color: #374151;
+}
+
+.chat-record-item-time {
+  font-size: 11px;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.chat-record-item-body {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text);
+  word-break: break-word;
+}
+
 .inline-emoji {
   width: 22px;
   height: 22px;

--- a/electron/services/exportService.ts
+++ b/electron/services/exportService.ts
@@ -1656,43 +1656,50 @@ class ExportService {
       const type = this.extractXmlValue(content, 'type')
       if (type !== '19') return undefined
 
-      // 提取 recorditem 中的 CDATA
-      const match = /<recorditem>[\s\S]*?<!\[CDATA\[([\s\S]*?)\]\]>[\s\S]*?<\/recorditem>/.exec(content)
-      if (!match) return undefined
+      const parseRecordItemBody = (body: string, datatype = 0) => {
+        const datasizeRaw = this.extractXmlValue(body, 'datasize')
+        const datasize = datasizeRaw ? parseInt(datasizeRaw, 10) : undefined
 
-      const innerXml = match[1]
-      const items: any[] = []
-      const itemRegex = /<dataitem\s+(.*?)>([\s\S]*?)<\/dataitem>/g
-      let itemMatch
-
-      while ((itemMatch = itemRegex.exec(innerXml)) !== null) {
-        const attrs = itemMatch[1]
-        const body = itemMatch[2]
-
-        const datatypeMatch = /datatype="(\d+)"/.exec(attrs)
-        const datatype = datatypeMatch ? parseInt(datatypeMatch[1]) : 0
-
-        const sourcename = this.extractXmlValue(body, 'sourcename')
-        const sourcetime = this.extractXmlValue(body, 'sourcetime')
-        const sourceheadurl = this.extractXmlValue(body, 'sourceheadurl')
-        const datadesc = this.extractXmlValue(body, 'datadesc')
-        const datatitle = this.extractXmlValue(body, 'datatitle')
-        const fileext = this.extractXmlValue(body, 'fileext')
-        const datasize = parseInt(this.extractXmlValue(body, 'datasize') || '0')
-
-        items.push({
+        return {
           datatype,
-          sourcename,
-          sourcetime,
-          sourceheadurl,
-          datadesc: this.decodeHtmlEntities(datadesc),
-          datatitle: this.decodeHtmlEntities(datatitle),
-          fileext,
-          datasize
-        })
+          sourcename: this.extractXmlValue(body, 'sourcename'),
+          sourcetime: this.extractXmlValue(body, 'sourcetime'),
+          sourceheadurl: this.extractXmlValue(body, 'sourceheadurl') || undefined,
+          datadesc: this.decodeHtmlEntities(this.extractXmlValue(body, 'datadesc')) || undefined,
+          datatitle: this.decodeHtmlEntities(this.extractXmlValue(body, 'datatitle')) || undefined,
+          fileext: this.extractXmlValue(body, 'fileext') || undefined,
+          datasize: Number.isFinite(datasize) ? datasize : undefined
+        }
       }
 
-      return items.length > 0 ? items : undefined
+      const cdataMatch = /<recorditem>[\s\S]*?<!\[CDATA\[([\s\S]*?)\]\]>[\s\S]*?<\/recorditem>/i.exec(content)
+      if (cdataMatch) {
+        const items: any[] = []
+        const itemRegex = /<dataitem\b([^>]*)>([\s\S]*?)<\/dataitem>/gi
+        let itemMatch: RegExpExecArray | null
+
+        while ((itemMatch = itemRegex.exec(cdataMatch[1])) !== null) {
+          const datatypeMatch = /datatype="(\d+)"/i.exec(itemMatch[1])
+          const datatype = datatypeMatch ? parseInt(datatypeMatch[1], 10) : 0
+          items.push(parseRecordItemBody(itemMatch[2], datatype))
+        }
+
+        if (items.length > 0) {
+          return items
+        }
+      }
+
+      const legacyItems: any[] = []
+      const recordItemRegex = /<recorditem>([\s\S]*?)<\/recorditem>/gi
+      let match: RegExpExecArray | null
+
+      while ((match = recordItemRegex.exec(content)) !== null) {
+        const datatypeStr = this.extractXmlValue(match[1], 'datatype')
+        const datatype = datatypeStr ? parseInt(datatypeStr, 10) : 0
+        legacyItems.push(parseRecordItemBody(match[1], datatype))
+      }
+
+      return legacyItems.length > 0 ? legacyItems : undefined
     } catch (e) {
       console.error('ExportService: 解析聊天记录失败:', e)
       return undefined
@@ -2082,6 +2089,96 @@ class ExportService {
       return this.escapeHtml(part)
     })
     return rendered.join('')
+  }
+
+  private getChatRecordPreviewText(record: {
+    datatype?: number
+    datadesc?: string
+    datatitle?: string
+    fileext?: string
+    duration?: number
+  }): string {
+    const text = record.datadesc || record.datatitle || ''
+    if (text) return text
+
+    switch (record.datatype) {
+      case 3:
+        return '[图片]'
+      case 34:
+        return record.duration ? `[语音] ${(record.duration / 1000).toFixed(0)}"` : '[语音]'
+      case 43:
+        return '[视频]'
+      case 47:
+        return '[动画表情]'
+      case 49:
+      case 8:
+      case 6:
+        return record.fileext ? `[文件] .${record.fileext}` : '[文件]'
+      default:
+        return '[消息]'
+    }
+  }
+
+  private formatChatRecordPlainText(input: {
+    title?: string
+    records?: Array<{
+      sourcename?: string
+      sourcetime?: string
+      datatype?: number
+      datadesc?: string
+      datatitle?: string
+      fileext?: string
+      duration?: number
+    }>
+  }): string {
+    const records = input.records || []
+    const header = input.title ? `[聊天记录] ${input.title}` : '[聊天记录]'
+    if (records.length === 0) return header
+
+    const lines = [header]
+    for (const record of records) {
+      const sender = record.sourcename || '未知发送者'
+      const time = record.sourcetime ? ` ${record.sourcetime}` : ''
+      const preview = this.getChatRecordPreviewText(record)
+      lines.push(`${sender}${time}: ${preview}`)
+    }
+    return lines.join('\n')
+  }
+
+  private renderHtmlChatRecordCard(input: {
+    title?: string
+    records?: Array<{
+      sourcename?: string
+      sourcetime?: string
+      datatype?: number
+      datadesc?: string
+      datatitle?: string
+      fileext?: string
+      duration?: number
+    }>
+  }): string {
+    const records = input.records || []
+    if (records.length === 0) return ''
+
+    const title = input.title || '聊天记录'
+    const itemsHtml = records.map((record) => {
+      const sender = record.sourcename || '未知发送者'
+      const time = record.sourcetime ? `<span class="chat-record-item-time">${this.escapeHtml(record.sourcetime)}</span>` : ''
+      const previewText = this.getChatRecordPreviewText(record)
+      return `<div class="chat-record-item">
+        <div class="chat-record-item-head">
+          <span class="chat-record-item-sender">${this.escapeHtml(sender)}</span>
+          ${time}
+        </div>
+        <div class="chat-record-item-body">${this.renderTextWithEmoji(previewText).replace(/\r?\n/g, '<br />')}</div>
+      </div>`
+    }).join('')
+
+    return `<div class="chat-record-card">
+      <div class="chat-record-card-title">${this.escapeHtml(title)}</div>
+      <div class="chat-record-card-meta">共 ${records.length} 条聊天记录</div>
+      <div class="chat-record-card-list">${itemsHtml}</div>
+    </div>`
   }
 
   private formatHtmlMessageText(content: string, localType: number, myWxid?: string, senderWxid?: string, isSend?: boolean): string {
@@ -2767,6 +2864,7 @@ class ExportService {
           let locationLng: number | undefined
           let locationPoiname: string | undefined
           let locationLabel: string | undefined
+          let chatRecordTitle: string | undefined
           let chatRecordList: any[] | undefined
 
           if (localType === 48 && content) {
@@ -2798,10 +2896,13 @@ class ExportService {
             } else if (localType === 43 && content) {
               // 视频消息
               videoMd5 = videoMd5 || this.extractVideoMd5(content)
-            } else if (collectMode === 'full' && localType === 49 && content) {
-              // 检查是否是聊天记录消息（type=19）
+            }
+
+            const looksLikeAppMsg = Boolean(content && (content.includes('<appmsg') || content.includes('&lt;appmsg')))
+            if (collectMode === 'full' && content && (localType === 49 || looksLikeAppMsg)) {
               const xmlType = this.extractXmlValue(content, 'type')
               if (xmlType === '19') {
+                chatRecordTitle = this.extractXmlValue(content, 'title') || '聊天记录'
                 chatRecordList = this.parseChatHistory(content)
               }
             }
@@ -2823,6 +2924,7 @@ class ExportService {
             locationLng,
             locationPoiname,
             locationLabel,
+            chatRecordTitle,
             chatRecordList
           })
 
@@ -4096,11 +4198,18 @@ class ExportService {
         if (appMsgMeta) {
           if (
             options.format === 'arkme-json' ||
-            (options.format === 'json' && (appMsgMeta.appMsgKind === 'quote' || appMsgMeta.appMsgKind === 'link'))
+            (options.format === 'json' && (
+              appMsgMeta.appMsgKind === 'quote' ||
+              appMsgMeta.appMsgKind === 'link' ||
+              appMsgMeta.appMsgKind === 'chat-record'
+            ))
           ) {
             Object.assign(msgObj, appMsgMeta)
           }
         }
+
+        if (msg.chatRecordTitle) msgObj.chatRecordTitle = msg.chatRecordTitle
+        if (msg.chatRecordList && msg.chatRecordList.length > 0) msgObj.chatRecordList = msg.chatRecordList
 
         if (options.format === 'arkme-json') {
           const contactCardMeta = this.extractArkmeContactCardMeta(msg.content, msg.localType)
@@ -4328,6 +4437,8 @@ class ExportService {
           if (message.contactCardCity) compactMessage.contactCardCity = message.contactCardCity
           if (message.contactCardSignature) compactMessage.contactCardSignature = message.contactCardSignature
           if (message.contactCardAvatar) compactMessage.contactCardAvatar = message.contactCardAvatar
+          if (message.chatRecordTitle) compactMessage.chatRecordTitle = message.chatRecordTitle
+          if (message.chatRecordList) compactMessage.chatRecordList = message.chatRecordList
           return compactMessage
         })
 
@@ -4862,6 +4973,12 @@ class ExportService {
             enrichedContentValue = this.appendTransferDesc(contentValue, transferDesc)
           }
         }
+        if (msg.chatRecordList && msg.chatRecordList.length > 0) {
+          enrichedContentValue = this.formatChatRecordPlainText({
+            title: msg.chatRecordTitle,
+            records: msg.chatRecordList
+          })
+        }
 
         // 调试日志
         if (msg.localType === 3 || msg.localType === 47) {
@@ -4888,7 +5005,8 @@ class ExportService {
         for (let col = 1; col <= maxColumns; col++) {
           const cell = worksheet.getCell(currentRow, col)
           cell.font = { name: 'Calibri', size: 11 }
-          cell.alignment = { vertical: 'middle', wrapText: false }
+          const hasMultiline = typeof cell.value === 'string' && String(cell.value).includes('\n')
+          cell.alignment = { vertical: 'middle', wrapText: hasMultiline }
         }
 
         currentRow++
@@ -5206,6 +5324,12 @@ class ExportService {
           if (transferDesc) {
             enrichedContentValue = this.appendTransferDesc(contentValue, transferDesc)
           }
+        }
+        if (msg.chatRecordList && msg.chatRecordList.length > 0) {
+          enrichedContentValue = this.formatChatRecordPlainText({
+            title: msg.chatRecordTitle,
+            records: msg.chatRecordList
+          })
         }
 
         let senderRole: string
@@ -5525,6 +5649,12 @@ class ExportService {
             msg.senderUsername,
             msg.isSend
           ) || '')
+        const enrichedMsgText = msg.chatRecordList && msg.chatRecordList.length > 0
+          ? this.formatChatRecordPlainText({
+            title: msg.chatRecordTitle,
+            records: msg.chatRecordList
+          })
+          : msgText
         const src = this.getWeCloneSource(msg, typeName, mediaItem)
 
         const row = [
@@ -5533,7 +5663,7 @@ class ExportService {
           typeName,
           msg.isSend ? 1 : 0,
           talker,
-          msgText,
+          enrichedMsgText,
           src,
           this.formatIsoTimestamp(msg.createTime)
         ]
@@ -5992,6 +6122,12 @@ class ExportService {
         }
 
         const linkCard = this.extractHtmlLinkCard(msg.content, msg.localType)
+        const chatRecordHtml = msg.chatRecordList && msg.chatRecordList.length > 0
+          ? this.renderHtmlChatRecordCard({
+            title: msg.chatRecordTitle,
+            records: msg.chatRecordList
+          })
+          : ''
 
         let mediaHtml = ''
         if (mediaItem?.kind === 'image') {
@@ -6007,7 +6143,9 @@ class ExportService {
           mediaHtml = `<video class="message-media video" controls preload="metadata"${posterAttr} src="${this.escapeAttribute(encodeURI(mediaItem.relativePath))}"></video>`
         }
 
-        const textHtml = linkCard
+        const textHtml = chatRecordHtml
+          ? chatRecordHtml
+          : linkCard
           ? `<div class="message-text"><a class="message-link-card" href="${this.escapeAttribute(linkCard.url)}" target="_blank" rel="noopener noreferrer">${this.renderTextWithEmoji(linkCard.title).replace(/\r?\n/g, '<br />')}</a></div>`
           : (textContent
             ? `<div class="message-text">${this.renderTextWithEmoji(textContent).replace(/\r?\n/g, '<br />')}</div>`

--- a/src/pages/ChatHistoryPage.tsx
+++ b/src/pages/ChatHistoryPage.tsx
@@ -36,61 +36,53 @@ export default function ChatHistoryPage() {
       const type = extractXmlValue(content, 'type')
       if (type !== '19') return undefined
 
-      const match = /<recorditem>[\s\S]*?<!\[CDATA\[([\s\S]*?)\]\]>[\s\S]*?<\/recorditem>/.exec(content)
-      if (!match) return undefined
+      const parseRecordItemBody = (body: string, datatype = 0): ChatRecordItem => ({
+        datatype,
+        sourcename: extractXmlValue(body, 'sourcename'),
+        sourcetime: extractXmlValue(body, 'sourcetime'),
+        sourceheadurl: extractXmlValue(body, 'sourceheadurl'),
+        datadesc: decodeHtmlEntities(extractXmlValue(body, 'datadesc')),
+        datatitle: decodeHtmlEntities(extractXmlValue(body, 'datatitle')),
+        fileext: extractXmlValue(body, 'fileext'),
+        datasize: parseInt(extractXmlValue(body, 'datasize') || '0'),
+        messageuuid: extractXmlValue(body, 'messageuuid'),
+        dataurl: decodeHtmlEntities(extractXmlValue(body, 'dataurl')),
+        datathumburl: decodeHtmlEntities(extractXmlValue(body, 'datathumburl') || extractXmlValue(body, 'thumburl')),
+        datacdnurl: decodeHtmlEntities(extractXmlValue(body, 'datacdnurl') || extractXmlValue(body, 'cdnurl')),
+        aeskey: decodeHtmlEntities(extractXmlValue(body, 'aeskey') || extractXmlValue(body, 'qaeskey')),
+        md5: extractXmlValue(body, 'md5') || extractXmlValue(body, 'datamd5'),
+        imgheight: parseInt(extractXmlValue(body, 'imgheight') || '0'),
+        imgwidth: parseInt(extractXmlValue(body, 'imgwidth') || '0'),
+        duration: parseInt(extractXmlValue(body, 'duration') || '0')
+      })
 
-      const innerXml = match[1]
-      const items: ChatRecordItem[] = []
-      const itemRegex = /<dataitem\s+(.*?)>([\s\S]*?)<\/dataitem>/g
-      let itemMatch: RegExpExecArray | null
+      const cdataMatch = /<recorditem>[\s\S]*?<!\[CDATA\[([\s\S]*?)\]\]>[\s\S]*?<\/recorditem>/.exec(content)
+      if (cdataMatch) {
+        const items: ChatRecordItem[] = []
+        const itemRegex = /<dataitem\b([^>]*)>([\s\S]*?)<\/dataitem>/gi
+        let itemMatch: RegExpExecArray | null
 
-      while ((itemMatch = itemRegex.exec(innerXml)) !== null) {
-        const attrs = itemMatch[1]
-        const body = itemMatch[2]
+        while ((itemMatch = itemRegex.exec(cdataMatch[1])) !== null) {
+          const datatypeMatch = /datatype="(\d+)"/i.exec(itemMatch[1])
+          const datatype = datatypeMatch ? parseInt(datatypeMatch[1], 10) : 0
+          items.push(parseRecordItemBody(itemMatch[2], datatype))
+        }
 
-        const datatypeMatch = /datatype="(\d+)"/.exec(attrs)
-        const datatype = datatypeMatch ? parseInt(datatypeMatch[1]) : 0
-
-        const sourcename = extractXmlValue(body, 'sourcename')
-        const sourcetime = extractXmlValue(body, 'sourcetime')
-        const sourceheadurl = extractXmlValue(body, 'sourceheadurl')
-        const datadesc = extractXmlValue(body, 'datadesc')
-        const datatitle = extractXmlValue(body, 'datatitle')
-        const fileext = extractXmlValue(body, 'fileext')
-        const datasize = parseInt(extractXmlValue(body, 'datasize') || '0')
-        const messageuuid = extractXmlValue(body, 'messageuuid')
-
-        const dataurl = extractXmlValue(body, 'dataurl')
-        const datathumburl = extractXmlValue(body, 'datathumburl') || extractXmlValue(body, 'thumburl')
-        const datacdnurl = extractXmlValue(body, 'datacdnurl') || extractXmlValue(body, 'cdnurl')
-        const aeskey = extractXmlValue(body, 'aeskey') || extractXmlValue(body, 'qaeskey')
-        const md5 = extractXmlValue(body, 'md5') || extractXmlValue(body, 'datamd5')
-        const imgheight = parseInt(extractXmlValue(body, 'imgheight') || '0')
-        const imgwidth = parseInt(extractXmlValue(body, 'imgwidth') || '0')
-        const duration = parseInt(extractXmlValue(body, 'duration') || '0')
-
-        items.push({
-          datatype,
-          sourcename,
-          sourcetime,
-          sourceheadurl,
-          datadesc: decodeHtmlEntities(datadesc),
-          datatitle: decodeHtmlEntities(datatitle),
-          fileext,
-          datasize,
-          messageuuid,
-          dataurl: decodeHtmlEntities(dataurl),
-          datathumburl: decodeHtmlEntities(datathumburl),
-          datacdnurl: decodeHtmlEntities(datacdnurl),
-          aeskey: decodeHtmlEntities(aeskey),
-          md5,
-          imgheight,
-          imgwidth,
-          duration
-        })
+        if (items.length > 0) {
+          return items
+        }
       }
 
-      return items.length > 0 ? items : undefined
+      const legacyItems: ChatRecordItem[] = []
+      const recordItemRegex = /<recorditem>([\s\S]*?)<\/recorditem>/gi
+      let match: RegExpExecArray | null
+
+      while ((match = recordItemRegex.exec(content)) !== null) {
+        const datatype = parseInt(extractXmlValue(match[1], 'datatype') || '0')
+        legacyItems.push(parseRecordItemBody(match[1], datatype))
+      }
+
+      return legacyItems.length > 0 ? legacyItems : undefined
     } catch (e) {
       console.error('前端解析聊天记录失败:', e)
       return undefined
@@ -131,8 +123,10 @@ export default function ChatHistoryPage() {
           let records: ChatRecordItem[] | undefined = msg.chatRecordList
 
           // 如果后端没有解析到，则在前端兜底解析一次
-          if ((!records || records.length === 0) && msg.content) {
-            records = parseChatHistory(msg.content) || []
+          const fallbackRecords = msg.content ? (parseChatHistory(msg.content) || []) : []
+
+          if ((!records || records.length === 0) && fallbackRecords.length > 0) {
+            records = fallbackRecords
           }
 
           if (records && records.length > 0) {


### PR DESCRIPTION
  ## 问题
  转发聊天记录在页面或导出中只显示缩略信息，内部折叠消息未被正确解析或导出。

  ## 修复
  - 修复 `type=19` 转发聊天记录解析，兼容 `recorditem -> CDATA -> dataitem` 结构
  - 修复大 `localType` 场景下导出链路漏解析 `appmsg` 的问题
  - 修复 HTML 导出对转发聊天记录的展开展示
  - 修复 JSON/Excel/TXT/WeClone 等导出格式对转发聊天记录的内容输出

  ## 验证
  - 页面聊天记录详情显示正常
  - HTML 导出显示完整转发聊天记录
  - JSON 导出包含完整 `chatRecordList`
  - 其他文本类导出可展开转发内容
  - `npm run typecheck` 通过