### PR TITLE
fix: node25使用pnpm拉取文件时，ajv导致拉取失败的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,9 @@
       "lodash": ">=4.17.21",
       "brace-expansion": ">=1.1.11",
       "picomatch": ">=2.3.1",
-      "ajv": ">=8.18.0"
+      "ajv": ">=8.18.0",
+      "ajv-keywords@3>ajv": "^6.12.6",
+      "@develar/schema-utils>ajv": "^6.12.6"
     }
   },
   "build": {


### PR DESCRIPTION
更改内容：在package.json文件中，保持全局的ajv版本不变。ajv-keywords@3和@develar/schema-utils里面用到的ajv版本锁定为6.12.6
测试环境：
node v25.9.0
system arch linux
pnpm v10.27.0