### PR TITLE
#580 修复与部分引用功能相关联的无法读取解密配置的问题

### DIFF
--- a/electron/exportWorker.ts
+++ b/electron/exportWorker.ts
@@ -5,6 +5,9 @@ interface ExportWorkerConfig {
   sessionIds: string[]
   outputDir: string
   options: ExportOptions
+  dbPath?: string
+  decryptKey?: string
+  myWxid?: string
   resourcesPath?: string
   userDataPath?: string
   logEnabled?: boolean
@@ -29,6 +32,11 @@ async function run() {
 
   wcdbService.setPaths(config.resourcesPath || '', config.userDataPath || '')
   wcdbService.setLogEnabled(config.logEnabled === true)
+  exportService.setRuntimeConfig({
+    dbPath: config.dbPath,
+    decryptKey: config.decryptKey,
+    myWxid: config.myWxid
+  })
 
   const result = await exportService.exportSessions(
     Array.isArray(config.sessionIds) ? config.sessionIds : [],

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2362,6 +2362,9 @@ function registerIpcHandlers() {
     const cfg = configService || new ConfigService()
     configService = cfg
     const logEnabled = cfg.get('logEnabled')
+    const dbPath = String(cfg.get('dbPath') || '').trim()
+    const decryptKey = String(cfg.get('decryptKey') || '').trim()
+    const myWxid = String(cfg.get('myWxid') || '').trim()
     const resourcesPath = app.isPackaged
       ? join(process.resourcesPath, 'resources')
       : join(app.getAppPath(), 'resources')
@@ -2375,6 +2378,9 @@ function registerIpcHandlers() {
             sessionIds,
             outputDir,
             options,
+            dbPath,
+            decryptKey,
+            myWxid,
             resourcesPath,
             userDataPath,
             logEnabled

--- a/electron/services/config.ts
+++ b/electron/services/config.ts
@@ -5,6 +5,13 @@ import Store from 'electron-store'
 
 // 加密前缀标记
 const SAFE_PREFIX = 'safe:'  // safeStorage 加密（普通模式）
+const isSafeStorageAvailable = (): boolean => {
+  try {
+    return typeof safeStorage?.isEncryptionAvailable === 'function' && safeStorage.isEncryptionAvailable()
+  } catch {
+    return false
+  }
+}
 const LOCK_PREFIX = 'lock:'  // 密码派生密钥加密（锁定模式）
 
 interface ConfigSchema {
@@ -257,7 +264,7 @@ export class ConfigService {
   private safeEncrypt(plaintext: string): string {
     if (!plaintext) return ''
     if (plaintext.startsWith(SAFE_PREFIX)) return plaintext
-    if (!safeStorage.isEncryptionAvailable()) return plaintext
+    if (!isSafeStorageAvailable()) return plaintext
     const encrypted = safeStorage.encryptString(plaintext)
     return SAFE_PREFIX + encrypted.toString('base64')
   }
@@ -265,7 +272,7 @@ export class ConfigService {
   private safeDecrypt(stored: string): string {
     if (!stored) return ''
     if (!stored.startsWith(SAFE_PREFIX)) return stored
-    if (!safeStorage.isEncryptionAvailable()) return ''
+    if (!isSafeStorageAvailable()) return ''
     try {
       const buf = Buffer.from(stored.slice(SAFE_PREFIX.length), 'base64')
       return safeStorage.decryptString(buf)

--- a/electron/services/exportService.ts
+++ b/electron/services/exportService.ts
@@ -254,6 +254,7 @@ async function parallelLimit<T, R>(
 
 class ExportService {
   private configService: ConfigService
+  private runtimeConfig: { dbPath?: string; decryptKey?: string; myWxid?: string } | null = null
   private contactCache: LRUCache<string, { displayName: string; avatarUrl?: string }>
   private inlineEmojiCache: LRUCache<string, string>
   private htmlStyleCache: string | null = null
@@ -293,6 +294,10 @@ class ExportService {
     const error = new Error('导出任务已停止')
     ;(error as Error & { code?: string }).code = this.STOP_ERROR_CODE
     return error
+  }
+
+  setRuntimeConfig(config: { dbPath?: string; decryptKey?: string; myWxid?: string } | null): void {
+    this.runtimeConfig = config
   }
 
   private normalizeSessionIds(sessionIds: string[]): string[] {
@@ -1316,9 +1321,9 @@ class ExportService {
   }
 
   private async ensureConnected(): Promise<{ success: boolean; cleanedWxid?: string; error?: string }> {
-    const wxid = this.configService.get('myWxid')
-    const dbPath = this.configService.get('dbPath')
-    const decryptKey = this.configService.get('decryptKey')
+    const wxid = String(this.runtimeConfig?.myWxid || this.configService.get('myWxid') || '').trim()
+    const dbPath = String(this.runtimeConfig?.dbPath || this.configService.get('dbPath') || '').trim()
+    const decryptKey = String(this.runtimeConfig?.decryptKey || this.configService.get('decryptKey') || '').trim()
     if (!wxid) return { success: false, error: '请先在设置页面配置微信ID' }
     if (!dbPath) return { success: false, error: '请先在设置页面配置数据库路径' }
     if (!decryptKey) return { success: false, error: '请先在设置页面配置解密密钥' }


### PR DESCRIPTION
## 说明

在本地验证 #580 的过程中，发现源码开发环境下导出流程在 Worker 中读取配置时会失败，导致导出报错或无法正确读取解密密钥。

## 修改

- 为 `safeStorage` 调用增加运行环境保护，避免在 Worker 环境中直接报错
- 主进程创建导出 Worker 时传入已解析的 `dbPath`、`decryptKey`、`myWxid`
- 导出 Worker 启动后优先使用主进程注入的运行时配置
- 避免导出 Worker 依赖自身去读取和解密关键配置

## 验证

- 已本地验证源码开发环境下导出流程可正常读取解密配置
- 已本地验证导出功能恢复正常

Related to #580
