### PR TITLE
fix: 修改依赖包sudo-prompt中的Node.util

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,13 @@
       "ajv": ">=8.18.0",
       "ajv-keywords@3>ajv": "^6.12.6",
       "@develar/schema-utils>ajv": "^6.12.6"
-    }
+    },
+    "patchedDependencies": {
+      "sudo-prompt@9.2.1": "patches/sudo-prompt@9.2.1.patch"
+    },
+    "onlyBuiltDependencies": [
+      "koffi"
+    ]
   },
   "build": {
     "appId": "com.WeFlow.app",

--- a/patches/sudo-prompt@9.2.1.patch
+++ b/patches/sudo-prompt@9.2.1.patch
@@ -1,0 +1,32 @@
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+deleted file mode 100644
+index 46ba454c45eb4019a50a06ea1f553bf00f71ff44..0000000000000000000000000000000000000000
+diff --git a/index.js b/index.js
+index acfd41ba963a34603b651022caa40a3c1aab1ace..4ed1d112475860c797cf9f6adf20d26b1daef1ec 100644
+--- a/index.js
++++ b/index.js
+@@ -32,20 +32,20 @@ function Exec() {
+     throw new Error('Command should be a string.');
+   }
+   if (arguments.length === 2) {
+-    if (Node.util.isObject(arguments[1])) {
++    if (arguments[1] !== null && typeof arguments[1] === 'object') {
+       options = arguments[1];
+-    } else if (Node.util.isFunction(arguments[1])) {
++    } else if (arguments[1] !== null && typeof arguments[1] === 'function') {
+       end = arguments[1];
+     } else {
+       throw new Error('Expected options or callback.');
+     }
+   } else if (arguments.length === 3) {
+-    if (Node.util.isObject(arguments[1])) {
++    if (arguments[1] !== null && typeof arguments[1] === 'object') {
+       options = arguments[1];
+     } else {
+       throw new Error('Expected options to be an object.');
+     }
+-    if (Node.util.isFunction(arguments[2])) {
++    if (arguments[2] !== null && typeof arguments[2] === 'function') {
+       end = arguments[2];
+     } else {
+       throw new Error('Expected callback to be a function.');


### PR DESCRIPTION
Node高版本弃用Node.util相关写法，会导致读取解密密钥失败，此处修改为官方推荐写法
error: Node.util.isObject is not a function
<img width="961" height="682" alt="mmexport1775464224630" src="https://github.com/user-attachments/assets/202443f1-0ce5-43a3-a7d2-9538adcabc8f" />

- 测试系统: arch linux
- Node: 22以及25
- electron41+
- pnpm: v10.27.0