### PR TITLE
fix: 非预期白名单通知行为

### DIFF
--- a/electron/windows/notificationWindow.ts
+++ b/electron/windows/notificationWindow.ts
@@ -116,8 +116,10 @@ export async function showNotification(data: any) {
   const filterMode = config.get("notificationFilterMode") || "all";
   const filterList = config.get("notificationFilterList") || [];
   const sessionId = typeof data.sessionId === "string" ? data.sessionId : "";
+  // 系统通知（如 "WeFlow 准备就绪"）不是聊天消息，不应受会话白/黑名单影响
+  const isSystemNotification = sessionId.startsWith("weflow-");
 
-  if (filterMode !== "all") {
+  if (!isSystemNotification && filterMode !== "all") {
     const isInList = sessionId !== "" && filterList.includes(sessionId);
     if (filterMode === "whitelist" && !isInList) {
       // 白名单模式：不在列表中则不显示（空列表视为全部拦截）

--- a/electron/windows/notificationWindow.ts
+++ b/electron/windows/notificationWindow.ts
@@ -115,12 +115,12 @@ export async function showNotification(data: any) {
   // 检查会话过滤
   const filterMode = config.get("notificationFilterMode") || "all";
   const filterList = config.get("notificationFilterList") || [];
-  const sessionId = data.sessionId;
+  const sessionId = typeof data.sessionId === "string" ? data.sessionId : "";
 
-  if (sessionId && filterMode !== "all" && filterList.length > 0) {
-    const isInList = filterList.includes(sessionId);
+  if (filterMode !== "all") {
+    const isInList = sessionId !== "" && filterList.includes(sessionId);
     if (filterMode === "whitelist" && !isInList) {
-      // 白名单模式：不在列表中则不显示
+      // 白名单模式：不在列表中则不显示（空列表视为全部拦截）
       return;
     }
     if (filterMode === "blacklist" && isInList) {


### PR DESCRIPTION
当前问题：
- 白名单为空时过滤完全失效
- 系统通知（`sessionId: 'weflow-system'`）被白名单拦截

原因：
- 白名单通知要求 `filterList.length > 0` 才可正确过滤
- 系统消息的 `sessionId` 不在可选白名单的列表内

第二点按照简单方式修复，如果要改成单独开关选择是否接受系统通知也可直接提出/修改。