### PR TITLE
 feat(message-push):优化防撤回逻辑与性能，修复黑白名单回归 (fixes #780)

### DIFF
--- a/electron/services/chatService.ts
+++ b/electron/services/chatService.ts
@@ -3473,7 +3473,7 @@ class ChatService {
     this.sessionStatsCacheService.clearScope(this.sessionStatsCacheScope)
   }
 
-  private collectSessionIdsFromPayload(payload: unknown): Set<string> {
+  private _collectSessionIdsFromPayload(payload: unknown): Set<string> {
     const ids = new Set<string>()
     const walk = (value: unknown, keyHint?: string) => {
       if (Array.isArray(value)) {
@@ -3521,9 +3521,9 @@ class ChatService {
     let ids = new Set<string>()
     if (maybeJson) {
       try {
-        ids = this.collectSessionIdsFromPayload(JSON.parse(maybeJson))
+        ids = this._collectSessionIdsFromPayload(JSON.parse(maybeJson))
       } catch {
-        ids = this.collectSessionIdsFromPayload(maybeJson)
+        ids = this._collectSessionIdsFromPayload(maybeJson)
       }
     }
 

--- a/electron/services/chatService.ts
+++ b/electron/services/chatService.ts
@@ -2241,6 +2241,10 @@ class ChatService {
     }
   }
 
+  collectSessionIdsFromPayload(payload: unknown): Set<string> {
+    return this._collectSessionIdsFromPayload(payload)
+  }
+
   private normalizeMessageOrder(messages: Message[]): Message[] {
     if (messages.length < 2) return messages
     const first = messages[0]

--- a/electron/services/httpService.ts
+++ b/electron/services/httpService.ts
@@ -234,7 +234,9 @@ class HttpService {
 
   broadcastMessagePush(payload: Record<string, unknown>): void {
     if (!this.running || this.messagePushClients.size === 0) return
-    const eventBody = `event: message.new\ndata: ${JSON.stringify(payload)}\n\n`
+    // 支持动态事件类型：默认是 message.new，防撤回消息使用 message.revoke
+    const eventType = String(payload.event || 'message.new')
+    const eventBody = `event: ${eventType}\ndata: ${JSON.stringify(payload)}\n\n`
 
     for (const client of Array.from(this.messagePushClients)) {
       try {

--- a/electron/services/httpService.ts
+++ b/electron/services/httpService.ts
@@ -109,6 +109,7 @@ class HttpService {
   private messagePushClients: Set<http.ServerResponse> = new Set()
   private messagePushHeartbeatTimer: ReturnType<typeof setInterval> | null = null
   private connectionMutex: boolean = false
+  private messagePushConnectedAt: number = 0
 
   constructor() {
     this.configService = ConfigService.getInstance()
@@ -169,7 +170,7 @@ class HttpService {
   /**
    * 停止 HTTP 服务
    */
-  async stop(): Promise<void> {
+  async   stop(): Promise<void> {
     return new Promise((resolve) => {
       if (this.server) {
         for (const client of this.messagePushClients) {
@@ -178,6 +179,7 @@ class HttpService {
           } catch {}
         }
         this.messagePushClients.clear()
+        this.messagePushConnectedAt = 0
         if (this.messagePushHeartbeatTimer) {
           clearInterval(this.messagePushHeartbeatTimer)
           this.messagePushHeartbeatTimer = null
@@ -230,6 +232,10 @@ class HttpService {
 
   getMessagePushStreamUrl(): string {
     return `http://${this.host}:${this.port}/api/v1/push/messages`
+  }
+
+  getMessagePushConnectedAt(): number {
+    return this.messagePushConnectedAt
   }
 
   broadcastMessagePush(payload: Record<string, unknown>): void {
@@ -447,6 +453,9 @@ class HttpService {
     res.write(`event: ready\ndata: ${JSON.stringify({ success: true, stream: this.getMessagePushStreamUrl() })}\n\n`)
 
     this.messagePushClients.add(res)
+    if (this.messagePushConnectedAt === 0) {
+      this.messagePushConnectedAt = Math.floor(Date.now() / 1000)
+    }
 
     const cleanup = () => {
       this.messagePushClients.delete(res)

--- a/electron/services/messagePushService.ts
+++ b/electron/services/messagePushService.ts
@@ -2,10 +2,6 @@ import { ConfigService } from './config'
 import { chatService, type ChatSession, type Message } from './chatService'
 import { wcdbService } from './wcdbService'
 import { httpService } from './httpService'
-import { promises as fs } from 'fs'
-import path from 'path'
-import { createHash } from 'crypto'
-import { pathToFileURL } from 'url'
 
 interface SessionBaseline {
   lastTimestamp: number
@@ -15,18 +11,27 @@ interface SessionBaseline {
 interface MessagePushPayload {
   event: 'message.new'
   sessionId: string
-  sessionType: 'private' | 'group' | 'official' | 'other'
   messageKey: string
   avatarUrl?: string
   sourceName: string
   groupName?: string
   content: string | null
+  emojiMd5?: string
+}
+
+interface MessageRevokePayload {
+  event: 'message.revoke'
+  sessionId: string
+  messageKey: string
+  avatarUrl?: string
+  sourceName: string
+  groupName?: string
+  content: string | null
+  originalServerId?: string
 }
 
 const PUSH_CONFIG_KEYS = new Set([
   'messagePushEnabled',
-  'messagePushFilterMode',
-  'messagePushFilterList',
   'dbPath',
   'decryptKey',
   'myWxid'
@@ -37,34 +42,26 @@ class MessagePushService {
   private readonly sessionBaseline = new Map<string, SessionBaseline>()
   private readonly recentMessageKeys = new Map<string, number>()
   private readonly groupNicknameCache = new Map<string, { nicknames: Record<string, string>; updatedAt: number }>()
-  private readonly pushAvatarCacheDir: string
-  private readonly pushAvatarDataCache = new Map<string, string>()
+  private readonly sessionInfoCache = new Map<string, { session: ChatSession | null; updatedAt: number }>()
   private readonly debounceMs = 350
   private readonly recentMessageTtlMs = 10 * 60 * 1000
   private readonly groupNicknameCacheTtlMs = 5 * 60 * 1000
+  private readonly sessionInfoCacheTtlMs = 60 * 1000
   private debounceTimer: ReturnType<typeof setTimeout> | null = null
   private processing = false
   private rerunRequested = false
   private started = false
   private baselineReady = false
-  private messageTableScanRequested = false
+  private readonly appStartTime = Math.floor(Date.now() / 1000)
 
   constructor() {
     this.configService = ConfigService.getInstance()
-    this.pushAvatarCacheDir = path.join(this.configService.getCacheBasePath(), 'push-avatar-files')
   }
 
   start(): void {
     if (this.started) return
     this.started = true
     void this.refreshConfiguration('startup')
-  }
-
-  stop(): void {
-    this.started = false
-    this.processing = false
-    this.rerunRequested = false
-    this.resetRuntimeState()
   }
 
   handleDbMonitorChange(type: string, json: string): void {
@@ -78,15 +75,349 @@ class MessagePushService {
       payload = null
     }
 
+    console.log(`[MessagePushService] handleDbMonitorChange: type=${type}, table=${payload?.table}, hasLocalType=${payload?.localType !== undefined}, hasContent=${!!payload?.content}`)
+    console.log(`[MessagePushService] payload 内容: ${JSON.stringify(payload)}`)
+
     const tableName = String(payload?.table || '').trim()
-    if (this.isSessionTableChange(tableName)) {
+
+    // session 表变化：检查是否有防撤回消息（立即检查），同时推送正常消息
+    if (tableName.toLowerCase() === 'session') {
+      console.log(`[MessagePushService] session 表变化，调用 handleSessionChangeForAntiRevoke`)
+      void this.handleSessionChangeForAntiRevoke(payload)
       this.scheduleSync()
       return
     }
 
-    if (!tableName || this.isMessageTableChange(tableName)) {
-      this.scheduleSync({ scanMessageBackedSessions: true })
+    // 消息表变化：尝试直接推送（包含防撤回注入的消息）
+    if (tableName && this.isMessageTable(tableName)) {
+      console.log(`[MessagePushService] 消息表变化: ${tableName}，调用 handleMessageTableChange`)
+      console.log(`[MessagePushService] Message 表变化 payload: ${JSON.stringify(payload)}`)
+      void this.handleMessageTableChange(payload)
+      return
+    } else {
+      console.log(`[MessagePushService] 跳过 tableName="${tableName}", isMessageTable=false`)
     }
+
+    // 兜底：如果 payload 中包含消息相关的字段（localType、content、localId 等），
+    // 说明是消息表变化，尝试提取 sessionId 并检测防撤回
+    if (payload && this.hasMessageFields(payload)) {
+      console.log(`[MessagePushService] hasMessageFields=true, payload: ${JSON.stringify(payload)}`)
+      const sessionId = this.extractSessionIdFromPayload(payload)
+      console.log(`[MessagePushService] hasMessageFields=true, sessionId=${sessionId}`)
+      if (sessionId) {
+        console.log(`[MessagePushService] 调用 handleSessionChangeForAntiRevoke (兜底路径)`)
+        void this.handleSessionChangeForAntiRevoke(payload)
+      }
+      this.scheduleSync()
+      return
+    }
+
+    // 其他表（如未知表），保守处理，走 debounce
+    if (tableName) {
+      console.log(`[MessagePushService] 未知表: ${tableName}，走 debounce`)
+      this.scheduleSync()
+    }
+  }
+
+  private hasMessageFields(payload: Record<string, unknown>): boolean {
+    return (
+      typeof payload.localType === 'number' ||
+      typeof payload.localId === 'number' ||
+      (typeof payload.content === 'string' && payload.content.length > 0) ||
+      typeof payload.serverId === 'number' ||
+      typeof payload.createTime === 'number' ||
+      typeof payload.sortSeq === 'number'
+    )
+  }
+
+  private isMessageTable(tableName: string): boolean {
+    const normalized = tableName.toLowerCase()
+    return normalized.includes('msg') ||
+           normalized.includes('message') ||
+           normalized.includes('chat') ||
+           normalized === 'contact' ||
+           normalized === 'chatmsg' ||
+           normalized === 'messagelist' ||
+           normalized === 'msgqueue'
+  }
+
+  private async handleSessionChangeForAntiRevoke(payload: Record<string, unknown> | null): Promise<void> {
+    // Session 表变化时，立即查询最近活跃的会话来检测防撤回消息
+    // 因为数据库监控无法区分具体哪个 Message 表变化，所以需要主动查询
+    console.log(`[MessagePushService] handleSessionChangeForAntiRevoke: Session 表变化，立即检查所有最近会话`)
+
+    // 获取最近活跃的会话列表
+    const sessionsResult = await chatService.getSessions()
+    if (!sessionsResult.success || !sessionsResult.sessions || sessionsResult.sessions.length === 0) {
+      console.log(`[MessagePushService] handleSessionChangeForAntiRevoke: 无会话数据`)
+      return
+    }
+
+    const sessions = sessionsResult.sessions as ChatSession[]
+    console.log(`[MessagePushService] handleSessionChangeForAntiRevoke: 共 ${sessions.length} 个会话需要检查`)
+
+    // 立即检查所有会话（并行查询，每批 5 个）
+    const batchSize = 5
+    let foundCount = 0
+
+    for (let i = 0; i < sessions.length; i += batchSize) {
+      const batch = sessions.slice(i, i + batchSize)
+      const results = await Promise.all(
+        batch.map(session => this.queryAntiRevokeInSession(session.username))
+      )
+      foundCount += results.filter(Boolean).length
+    }
+
+    console.log(`[MessagePushService] handleSessionChangeForAntiRevoke: 检查完成，共发现 ${foundCount} 个会话有防撤回消息`)
+  }
+
+  private async queryAntiRevokeInSession(sessionId: string): Promise<boolean> {
+    // 直接查询该会话的最新消息，不依赖 baseline
+    // 使用当前时间 - 300秒（5分钟）作为起始时间，确保能查到最近的消息
+    const since = Math.floor(Date.now() / 1000) - 300
+    console.log(`[MessagePushService] queryAntiRevokeInSession: sessionId=${sessionId}, since=${since}`)
+
+    const newMessagesResult = await chatService.getNewMessages(sessionId, since, 20)
+    if (!newMessagesResult.success || !newMessagesResult.messages || newMessagesResult.messages.length === 0) {
+      console.log(`[MessagePushService] queryAntiRevokeInSession: 无新消息`)
+      return false
+    }
+
+    console.log(`[MessagePushService] queryAntiRevokeInSession: 查到 ${newMessagesResult.messages.length} 条消息`)
+
+    // 检查最新消息中是否有防撤回注入的消息
+    for (const message of newMessagesResult.messages) {
+      const messageKey = String(message.messageKey || '').trim()
+      if (!messageKey) continue
+
+      const localType = Number(message.localType || 0)
+      const content = String(message.rawContent || message.content || '').trim()
+
+      console.log(`[MessagePushService] 检查消息: localType=${localType}, content="${content.substring(0, 50)}"`)
+
+      if (this.isAntiRevokeInjectMessage(localType, content)) {
+        // 检查撤回事件是否已推送过
+        const revokeMessageKey = `${messageKey}:revoke`
+        if (this.isRecentMessage(revokeMessageKey)) {
+          console.log(`[MessagePushService] queryAntiRevokeInSession: 撤回事件已推送过，跳过`)
+          continue
+        }
+        console.log(`[MessagePushService] queryAntiRevokeInSession: 检测到防撤回消息，立即推送`)
+        // 找到防撤回消息，立即推送
+        await this.pushAntiRevokeMessageFromMessage(sessionId, message)
+        // 推送后直接返回 true，避免同一会话的多条消息重复推送
+        return true
+      }
+    }
+    return false
+  }
+
+  private extractSessionIdFromPayload(payload: Record<string, unknown> | null): string | null {
+    if (!payload) {
+      console.log(`[MessagePushService] extractSessionIdFromPayload: payload 为空`)
+      return null
+    }
+
+    // 尝试多种字段名
+    const sessionId = String(
+      payload.sessionId ||
+      payload.talker ||
+      payload.username ||
+      payload.susername ||
+      payload.wxid ||
+      payload.fromUsername ||
+      payload.toUsername ||
+      payload.from ||
+      payload.to ||
+      payload.chatName ||
+      payload.chatId ||
+      payload.conversationId ||
+      ''
+    ).trim()
+
+    // 过滤掉明显不是 sessionId 的值
+    if (!sessionId || sessionId.length < 3) {
+      console.log(`[MessagePushService] extractSessionIdFromPayload: sessionId="${sessionId}" 太短或为空`)
+      return null
+    }
+
+    // 过滤掉数字形式的值（这通常是 localId 等）
+    if (/^\d+$/.test(sessionId)) {
+      console.log(`[MessagePushService] extractSessionIdFromPayload: sessionId="${sessionId}" 是纯数字`)
+      return null
+    }
+
+    console.log(`[MessagePushService] extractSessionIdFromPayload: 提取到 sessionId="${sessionId}"`)
+    return sessionId
+  }
+
+  private async handleMessageTableChange(payload: Record<string, unknown> | null): Promise<void> {
+    if (!payload) {
+      console.log(`[MessagePushService] handleMessageTableChange: payload 为空，走 debounce`)
+      this.scheduleSync()
+      return
+    }
+
+    // 尝试从 payload 中提取会话信息
+    const sessionId = this.extractSessionIdFromPayload(payload)
+    if (!sessionId) {
+      console.log(`[MessagePushService] handleMessageTableChange: 无法提取 sessionId，走 debounce`)
+      // 无法提取 sessionId，走 debounce 流程
+      this.scheduleSync()
+      return
+    }
+
+    console.log(`[MessagePushService] handleMessageTableChange: sessionId=${sessionId}`)
+
+    // 检查是否是防撤回注入的消息
+    const content = String(payload.content || payload.rawContent || '').trim()
+    const localType = Number(payload.localType || payload.type || 0)
+    const isAntiRevokeMessage = this.isAntiRevokeInjectMessage(localType, content)
+
+    if (isAntiRevokeMessage) {
+      // 防撤回消息：直接推送
+      await this.pushAntiRevokeMessageDirect(sessionId, payload)
+    } else {
+      // 其他消息变化：走 debounce
+      this.scheduleSync()
+    }
+  }
+
+  private isAntiRevokeInjectMessage(localType: number, content: string): boolean {
+    // localType 为 10000（系统消息）且内容包含撤回相关提示
+    if (localType === 10000) {
+      const normalizedContent = content.toLowerCase()
+      return normalizedContent.includes('撤回') ||
+             normalizedContent.includes('recall') ||
+             normalizedContent.includes('revoke') ||
+             normalizedContent.includes('尝试撤回')
+    }
+    return false
+  }
+
+  private async pushAntiRevokeMessageFromMessage(sessionId: string, message: Message): Promise<void> {
+    const messageKey = String(message.messageKey || '').trim()
+    if (!messageKey) {
+      console.log(`[MessagePushService] pushAntiRevokeMessageFromMessage: messageKey 为空`)
+      return
+    }
+
+    // 为撤回事件生成唯一的 messageKey，避免与被撤回消息的 messageKey 冲突
+    const revokeMessageKey = `${messageKey}:revoke`
+    const content = String(message.parsedContent || message.rawContent || '[系统消息]').trim()
+    const serverId = message.serverId ? String(message.serverId) : undefined
+
+    console.log(`[MessagePushService] pushAntiRevokeMessageFromMessage: 准备推送撤回事件, messageKey=${messageKey}, revokeMessageKey=${revokeMessageKey}`)
+
+    // 立即构建 payload，使用缓存的会话信息
+    const isGroup = sessionId.endsWith('@chatroom')
+    const cachedSession = this.getCachedSession(sessionId)
+    const session = cachedSession || undefined
+
+    let sourceName = session?.displayName || sessionId
+    let avatarUrl = session?.avatarUrl
+
+    if (!session) {
+      // 异步获取会话信息并缓存
+      this.refreshSessionInfoCache(sessionId)
+    }
+
+    const revokePayload: MessageRevokePayload = {
+      event: 'message.revoke',
+      sessionId,
+      messageKey: revokeMessageKey,
+      avatarUrl,
+      sourceName,
+      groupName: isGroup ? (session?.displayName || sessionId) : undefined,
+      content,
+      originalServerId: serverId
+    }
+
+    console.log(`[MessagePushService] pushAntiRevokeMessageFromMessage: 调用 broadcastMessagePush`)
+    // 立即推送，不等待异步会话信息获取
+    httpService.broadcastMessagePush(revokePayload as unknown as Record<string, unknown>)
+    this.rememberMessageKey(revokeMessageKey)
+    console.log(`[MessagePushService] pushAntiRevokeMessageFromMessage: broadcastMessagePush 完成`)
+  }
+
+  private getCachedSession(sessionId: string): ChatSession | null {
+    const cached = this.sessionInfoCache.get(sessionId)
+    if (cached && Date.now() - cached.updatedAt < this.sessionInfoCacheTtlMs) {
+      return cached.session
+    }
+    return null
+  }
+
+  private async refreshSessionInfoCache(sessionId: string): Promise<void> {
+    try {
+      const sessionsResult = await chatService.getSessions()
+      if (sessionsResult.success && sessionsResult.sessions) {
+        const session = (sessionsResult.sessions as ChatSession[]).find(s => s.username === sessionId)
+        this.sessionInfoCache.set(sessionId, { session: session || null, updatedAt: Date.now() })
+      }
+    } catch {
+      // 忽略错误
+    }
+  }
+
+  private async pushAntiRevokeMessageDirect(sessionId: string, payload: Record<string, unknown>): Promise<void> {
+    const baseMessageKey = String(payload.messageKey || payload.key || `${sessionId}_${payload.localId || payload.id || Date.now()}`).trim()
+    // 为撤回事件生成唯一的 messageKey
+    const revokeMessageKey = `${baseMessageKey}:revoke`
+
+    // 检查撤回事件是否已经推送过
+    if (this.isRecentMessage(revokeMessageKey)) {
+      return
+    }
+
+    const content = String(payload.content || payload.rawContent || '[系统消息]').trim()
+    const serverId = payload.serverId ? String(payload.serverId) : undefined
+    const isGroup = sessionId.endsWith('@chatroom')
+
+    // 获取会话信息
+    const sessionsResult = await chatService.getSessions()
+    if (!sessionsResult.success || !sessionsResult.sessions) {
+      return
+    }
+
+    const session = (sessionsResult.sessions as ChatSession[]).find(s => s.username === sessionId)
+
+    let sourceName: string
+    let avatarUrl: string | undefined
+
+    if (session) {
+      if (isGroup) {
+        const groupInfo = await chatService.getContactAvatar(sessionId)
+        avatarUrl = session.avatarUrl || groupInfo?.avatarUrl
+        sourceName = session.displayName || groupInfo?.displayName || sessionId
+      } else {
+        const contactInfo = await chatService.getContactAvatar(sessionId)
+        avatarUrl = session.avatarUrl || contactInfo?.avatarUrl
+        sourceName = session.displayName || contactInfo?.displayName || sessionId
+      }
+    } else {
+      if (isGroup) {
+        sourceName = sessionId
+      } else {
+        const contactInfo = await chatService.getContactAvatar(sessionId)
+        avatarUrl = contactInfo?.avatarUrl
+        sourceName = contactInfo?.displayName || sessionId
+      }
+    }
+
+    const revokePayload: MessageRevokePayload = {
+      event: 'message.revoke',
+      sessionId,
+      messageKey: revokeMessageKey,
+      avatarUrl,
+      sourceName,
+      groupName: isGroup ? (session?.displayName || sessionId) : undefined,
+      content,
+      originalServerId: serverId
+    }
+
+    httpService.broadcastMessagePush(revokePayload as unknown as Record<string, unknown>)
+    this.rememberMessageKey(revokeMessageKey)
   }
 
   async handleConfigChanged(key: string): Promise<void> {
@@ -111,8 +442,8 @@ class MessagePushService {
     this.sessionBaseline.clear()
     this.recentMessageKeys.clear()
     this.groupNicknameCache.clear()
+    this.sessionInfoCache.clear()
     this.baselineReady = false
-    this.messageTableScanRequested = false
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer)
       this.debounceTimer = null
@@ -143,11 +474,7 @@ class MessagePushService {
     this.baselineReady = true
   }
 
-  private scheduleSync(options: { scanMessageBackedSessions?: boolean } = {}): void {
-    if (options.scanMessageBackedSessions) {
-      this.messageTableScanRequested = true
-    }
-
+  private scheduleSync(): void {
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer)
     }
@@ -167,8 +494,6 @@ class MessagePushService {
     this.processing = true
     try {
       if (!this.isPushEnabled()) return
-      const scanMessageBackedSessions = this.messageTableScanRequested
-      this.messageTableScanRequested = false
 
       const connectResult = await chatService.connect()
       if (!connectResult.success) {
@@ -191,46 +516,26 @@ class MessagePushService {
       const previousBaseline = new Map(this.sessionBaseline)
       this.setBaseline(sessions)
 
-      const candidates = sessions.filter((session) => {
-        const previous = previousBaseline.get(session.username)
-        if (this.shouldInspectSession(previous, session)) {
-          return true
-        }
-        return scanMessageBackedSessions && this.shouldScanMessageBackedSession(previous, session)
-      })
+      const candidates = sessions.filter((session) => this.shouldInspectSession(previousBaseline.get(session.username), session))
       for (const session of candidates) {
-        await this.pushSessionMessages(
-          session,
-          previousBaseline.get(session.username) || this.sessionBaseline.get(session.username)
-        )
+        await this.pushSessionMessages(session, previousBaseline.get(session.username))
       }
     } finally {
       this.processing = false
       if (this.rerunRequested) {
         this.rerunRequested = false
-        this.scheduleSync({ scanMessageBackedSessions: this.messageTableScanRequested })
+        this.scheduleSync()
       }
     }
   }
 
   private setBaseline(sessions: ChatSession[]): void {
-    const previousBaseline = new Map(this.sessionBaseline)
-    const nextBaseline = new Map<string, SessionBaseline>()
-    const nowSeconds = Math.floor(Date.now() / 1000)
     this.sessionBaseline.clear()
     for (const session of sessions) {
-      const username = String(session.username || '').trim()
-      if (!username) continue
-      const previous = previousBaseline.get(username)
-      const sessionTimestamp = Number(session.lastTimestamp || 0)
-      const initialTimestamp = sessionTimestamp > 0 ? sessionTimestamp : nowSeconds
-      nextBaseline.set(username, {
-        lastTimestamp: Math.max(sessionTimestamp, Number(previous?.lastTimestamp || 0), previous ? 0 : initialTimestamp),
+      this.sessionBaseline.set(session.username, {
+        lastTimestamp: Number(session.lastTimestamp || 0),
         unreadCount: Number(session.unreadCount || 0)
       })
-    }
-    for (const [username, baseline] of nextBaseline.entries()) {
-      this.sessionBaseline.set(username, baseline)
     }
   }
 
@@ -252,30 +557,17 @@ class MessagePushService {
       return unreadCount > 0 && lastTimestamp > 0
     }
 
-    return lastTimestamp > previous.lastTimestamp || unreadCount > previous.unreadCount
-  }
-
-  private shouldScanMessageBackedSession(previous: SessionBaseline | undefined, session: ChatSession): boolean {
-    const sessionId = String(session.username || '').trim()
-    if (!sessionId || sessionId.toLowerCase().includes('placeholder_foldgroup')) {
+    if (lastTimestamp <= previous.lastTimestamp) {
       return false
     }
 
-    const summary = String(session.summary || '').trim()
-    if (Number(session.lastMsgType || 0) === 10002 || summary.includes('撤回了一条消息')) {
-      return false
-    }
-
-    const sessionType = this.getSessionType(sessionId, session)
-    if (sessionType === 'private') {
-      return false
-    }
-
-    return Boolean(previous) || Number(session.lastTimestamp || 0) > 0
+    // unread 未增长时，大概率是自己发送、其他设备已读或状态同步，不作为主动推送
+    return unreadCount > previous.unreadCount
   }
 
   private async pushSessionMessages(session: ChatSession, previous: SessionBaseline | undefined): Promise<void> {
-    const since = Math.max(0, Number(previous?.lastTimestamp || 0))
+    // 如果没有 baseline，只查询程序启动后的消息，避免推送历史消息
+    const since = previous ? Math.max(0, Number(previous.lastTimestamp || 0) - 1) : this.appStartTime
     const newMessagesResult = await chatService.getNewMessages(session.username, since, 1000)
     if (!newMessagesResult.success || !newMessagesResult.messages || newMessagesResult.messages.length === 0) {
       return
@@ -286,7 +578,26 @@ class MessagePushService {
       if (!messageKey) continue
       if (message.isSend === 1) continue
 
-      if (previous && Number(message.createTime || 0) <= Number(previous.lastTimestamp || 0)) {
+      if (previous && Number(message.createTime || 0) < Number(previous.lastTimestamp || 0)) {
+        continue
+      }
+
+      // 无论如何，只推送程序启动后的消息
+      if (Number(message.createTime || 0) < this.appStartTime) {
+        continue
+      }
+
+      // 检查是否是防撤回注入的消息
+      const localType = Number(message.localType || 0)
+      const content = String(message.rawContent || message.content || '').trim()
+      if (this.isAntiRevokeInjectMessage(localType, content)) {
+        // 检查撤回事件是否已推送过
+        const revokeMessageKey = `${messageKey}:revoke`
+        if (this.isRecentMessage(revokeMessageKey)) {
+          continue
+        }
+        // 推送撤回事件
+        void this.pushAntiRevokeMessageFromMessage(session.username, message)
         continue
       }
 
@@ -296,11 +607,9 @@ class MessagePushService {
 
       const payload = await this.buildPayload(session, message)
       if (!payload) continue
-      if (!this.shouldPushPayload(payload)) continue
 
-      httpService.broadcastMessagePush(payload)
+      httpService.broadcastMessagePush(payload as unknown as Record<string, unknown>)
       this.rememberMessageKey(messageKey)
-      this.bumpSessionBaseline(session.username, message)
     }
   }
 
@@ -310,162 +619,42 @@ class MessagePushService {
     if (!sessionId || !messageKey) return null
 
     const isGroup = sessionId.endsWith('@chatroom')
-    const sessionType = this.getSessionType(sessionId, session)
     const content = this.getMessageDisplayContent(message)
+    const isEmoji = Number(message.localType || 0) === 47
+    const emojiMd5 = isEmoji ? (message.emojiMd5 || undefined) : undefined
 
     if (isGroup) {
       const groupInfo = await chatService.getContactAvatar(sessionId)
       const groupName = session.displayName || groupInfo?.displayName || sessionId
       const sourceName = await this.resolveGroupSourceName(sessionId, message, session)
-      const avatarUrl = await this.normalizePushAvatarUrl(session.avatarUrl || groupInfo?.avatarUrl)
       return {
         event: 'message.new',
         sessionId,
-        sessionType,
         messageKey,
-        avatarUrl,
+        avatarUrl: session.avatarUrl || groupInfo?.avatarUrl,
         groupName,
         sourceName,
-        content
+        content,
+        emojiMd5
       }
     }
 
     const contactInfo = await chatService.getContactAvatar(sessionId)
-    const avatarUrl = await this.normalizePushAvatarUrl(session.avatarUrl || contactInfo?.avatarUrl)
     return {
       event: 'message.new',
       sessionId,
-      sessionType,
       messageKey,
-      avatarUrl,
+      avatarUrl: session.avatarUrl || contactInfo?.avatarUrl,
       sourceName: session.displayName || contactInfo?.displayName || sessionId,
-      content
-    }
-  }
-
-  private async normalizePushAvatarUrl(avatarUrl?: string): Promise<string | undefined> {
-    const normalized = String(avatarUrl || '').trim()
-    if (!normalized) return undefined
-    if (!normalized.startsWith('data:image/')) {
-      return normalized
-    }
-
-    const cached = this.pushAvatarDataCache.get(normalized)
-    if (cached) return cached
-
-    const match = /^data:(image\/[a-zA-Z0-9.+-]+);base64,(.+)$/i.exec(normalized)
-    if (!match) return undefined
-
-    try {
-      const mimeType = match[1].toLowerCase()
-      const base64Data = match[2]
-      const imageBuffer = Buffer.from(base64Data, 'base64')
-      if (!imageBuffer.length) return undefined
-
-      const ext = this.getImageExtFromMime(mimeType)
-      const hash = createHash('sha1').update(normalized).digest('hex')
-      const filePath = path.join(this.pushAvatarCacheDir, `avatar_${hash}.${ext}`)
-
-      await fs.mkdir(this.pushAvatarCacheDir, { recursive: true })
-      try {
-        await fs.access(filePath)
-      } catch {
-        await fs.writeFile(filePath, imageBuffer)
-      }
-
-      const fileUrl = pathToFileURL(filePath).toString()
-      this.pushAvatarDataCache.set(normalized, fileUrl)
-      return fileUrl
-    } catch {
-      return undefined
-    }
-  }
-
-  private getImageExtFromMime(mimeType: string): string {
-    if (mimeType === 'image/png') return 'png'
-    if (mimeType === 'image/gif') return 'gif'
-    if (mimeType === 'image/webp') return 'webp'
-    return 'jpg'
-  }
-
-  private getSessionType(sessionId: string, session: ChatSession): MessagePushPayload['sessionType'] {
-    if (sessionId.endsWith('@chatroom')) {
-      return 'group'
-    }
-    if (sessionId.startsWith('gh_') || session.type === 'official') {
-      return 'official'
-    }
-    if (session.type === 'friend') {
-      return 'private'
-    }
-    return 'other'
-  }
-
-  private shouldPushPayload(payload: MessagePushPayload): boolean {
-    const sessionId = String(payload.sessionId || '').trim()
-    const filterMode = this.getMessagePushFilterMode()
-    if (filterMode === 'all') {
-      return true
-    }
-
-    const filterList = this.getMessagePushFilterList()
-    const listed = filterList.has(sessionId)
-    if (filterMode === 'whitelist') {
-      return listed
-    }
-    return !listed
-  }
-
-  private getMessagePushFilterMode(): 'all' | 'whitelist' | 'blacklist' {
-    const value = this.configService.get('messagePushFilterMode')
-    if (value === 'whitelist' || value === 'blacklist') return value
-    return 'all'
-  }
-
-  private getMessagePushFilterList(): Set<string> {
-    const value = this.configService.get('messagePushFilterList')
-    if (!Array.isArray(value)) return new Set()
-    return new Set(value.map((item) => String(item || '').trim()).filter(Boolean))
-  }
-
-  private isSessionTableChange(tableName: string): boolean {
-    return String(tableName || '').trim().toLowerCase() === 'session'
-  }
-
-  private isMessageTableChange(tableName: string): boolean {
-    const normalized = String(tableName || '').trim().toLowerCase()
-    if (!normalized) return false
-    return normalized === 'message' ||
-      normalized === 'msg' ||
-      normalized.startsWith('message_') ||
-      normalized.startsWith('msg_') ||
-      normalized.includes('message')
-  }
-
-  private bumpSessionBaseline(sessionId: string, message: Message): void {
-    const key = String(sessionId || '').trim()
-    if (!key) return
-
-    const createTime = Number(message.createTime || 0)
-    if (!Number.isFinite(createTime) || createTime <= 0) return
-
-    const current = this.sessionBaseline.get(key) || { lastTimestamp: 0, unreadCount: 0 }
-    if (createTime > current.lastTimestamp) {
-      this.sessionBaseline.set(key, {
-        ...current,
-        lastTimestamp: createTime
-      })
+      content,
+      emojiMd5
     }
   }
 
   private getMessageDisplayContent(message: Message): string | null {
-    const cleanOfficialPrefix = (value: string | null): string | null => {
-      if (!value) return value
-      return value.replace(/^\s*\[视频号\]\s*/u, '').trim() || value
-    }
     switch (Number(message.localType || 0)) {
       case 1:
-        return cleanOfficialPrefix(message.rawContent || null)
+        return message.rawContent || null
       case 3:
         return '[图片]'
       case 34:
@@ -475,13 +664,13 @@ class MessagePushService {
       case 47:
         return '[表情]'
       case 42:
-        return cleanOfficialPrefix(message.cardNickname || '[名片]')
+        return message.cardNickname || '[名片]'
       case 48:
         return '[位置]'
       case 49:
-        return cleanOfficialPrefix(message.linkTitle || message.fileName || '[消息]')
+        return message.linkTitle || message.fileName || '[消息]'
       default:
-        return cleanOfficialPrefix(message.parsedContent || message.rawContent || null)
+        return message.parsedContent || message.rawContent || null
     }
   }
 

--- a/electron/services/messagePushService.ts
+++ b/electron/services/messagePushService.ts
@@ -2,6 +2,10 @@ import { ConfigService } from './config'
 import { chatService, type ChatSession, type Message } from './chatService'
 import { wcdbService } from './wcdbService'
 import { httpService } from './httpService'
+import { promises as fs } from 'fs'
+import path from 'path'
+import { createHash } from 'crypto'
+import { pathToFileURL } from 'url'
 
 interface SessionBaseline {
   lastTimestamp: number
@@ -11,6 +15,7 @@ interface SessionBaseline {
 interface MessagePushPayload {
   event: 'message.new'
   sessionId: string
+  sessionType: 'private' | 'group' | 'official' | 'other'
   messageKey: string
   avatarUrl?: string
   sourceName: string
@@ -22,6 +27,7 @@ interface MessagePushPayload {
 interface MessageRevokePayload {
   event: 'message.revoke'
   sessionId: string
+  sessionType: 'private' | 'group' | 'official' | 'other'
   messageKey: string
   avatarUrl?: string
   sourceName: string
@@ -32,6 +38,8 @@ interface MessageRevokePayload {
 
 const PUSH_CONFIG_KEYS = new Set([
   'messagePushEnabled',
+  'messagePushFilterMode',
+  'messagePushFilterList',
   'dbPath',
   'decryptKey',
   'myWxid'
@@ -42,26 +50,34 @@ class MessagePushService {
   private readonly sessionBaseline = new Map<string, SessionBaseline>()
   private readonly recentMessageKeys = new Map<string, number>()
   private readonly groupNicknameCache = new Map<string, { nicknames: Record<string, string>; updatedAt: number }>()
-  private readonly sessionInfoCache = new Map<string, { session: ChatSession | null; updatedAt: number }>()
+  private readonly pushAvatarCacheDir: string
+  private readonly pushAvatarDataCache = new Map<string, string>()
   private readonly debounceMs = 350
   private readonly recentMessageTtlMs = 10 * 60 * 1000
   private readonly groupNicknameCacheTtlMs = 5 * 60 * 1000
-  private readonly sessionInfoCacheTtlMs = 60 * 1000
+  private readonly appStartTime = Math.floor(Date.now() / 1000)
   private debounceTimer: ReturnType<typeof setTimeout> | null = null
   private processing = false
   private rerunRequested = false
   private started = false
   private baselineReady = false
-  private readonly appStartTime = Math.floor(Date.now() / 1000)
 
   constructor() {
     this.configService = ConfigService.getInstance()
+    this.pushAvatarCacheDir = path.join(this.configService.getCacheBasePath(), 'push-avatar-files')
   }
 
   start(): void {
     if (this.started) return
     this.started = true
     void this.refreshConfiguration('startup')
+  }
+
+  stop(): void {
+    this.started = false
+    this.processing = false
+    this.rerunRequested = false
+    this.resetRuntimeState()
   }
 
   handleDbMonitorChange(type: string, json: string): void {
@@ -141,84 +157,12 @@ class MessagePushService {
            normalized === 'msgqueue'
   }
 
-  private async handleSessionChangeForAntiRevoke(payload: Record<string, unknown> | null): Promise<void> {
-    // Session 表变化时，立即查询最近活跃的会话来检测防撤回消息
-    // 因为数据库监控无法区分具体哪个 Message 表变化，所以需要主动查询
-    console.log(`[MessagePushService] handleSessionChangeForAntiRevoke: Session 表变化，立即检查所有最近会话`)
-
-    // 获取最近活跃的会话列表
-    const sessionsResult = await chatService.getSessions()
-    if (!sessionsResult.success || !sessionsResult.sessions || sessionsResult.sessions.length === 0) {
-      console.log(`[MessagePushService] handleSessionChangeForAntiRevoke: 无会话数据`)
-      return
-    }
-
-    const sessions = sessionsResult.sessions as ChatSession[]
-    console.log(`[MessagePushService] handleSessionChangeForAntiRevoke: 共 ${sessions.length} 个会话需要检查`)
-
-    // 立即检查所有会话（并行查询，每批 5 个）
-    const batchSize = 5
-    let foundCount = 0
-
-    for (let i = 0; i < sessions.length; i += batchSize) {
-      const batch = sessions.slice(i, i + batchSize)
-      const results = await Promise.all(
-        batch.map(session => this.queryAntiRevokeInSession(session.username))
-      )
-      foundCount += results.filter(Boolean).length
-    }
-
-    console.log(`[MessagePushService] handleSessionChangeForAntiRevoke: 检查完成，共发现 ${foundCount} 个会话有防撤回消息`)
-  }
-
-  private async queryAntiRevokeInSession(sessionId: string): Promise<boolean> {
-    // 直接查询该会话的最新消息，不依赖 baseline
-    // 使用当前时间 - 300秒（5分钟）作为起始时间，确保能查到最近的消息
-    const since = Math.floor(Date.now() / 1000) - 300
-    console.log(`[MessagePushService] queryAntiRevokeInSession: sessionId=${sessionId}, since=${since}`)
-
-    const newMessagesResult = await chatService.getNewMessages(sessionId, since, 20)
-    if (!newMessagesResult.success || !newMessagesResult.messages || newMessagesResult.messages.length === 0) {
-      console.log(`[MessagePushService] queryAntiRevokeInSession: 无新消息`)
-      return false
-    }
-
-    console.log(`[MessagePushService] queryAntiRevokeInSession: 查到 ${newMessagesResult.messages.length} 条消息`)
-
-    // 检查最新消息中是否有防撤回注入的消息
-    for (const message of newMessagesResult.messages) {
-      const messageKey = String(message.messageKey || '').trim()
-      if (!messageKey) continue
-
-      const localType = Number(message.localType || 0)
-      const content = String(message.rawContent || message.content || '').trim()
-
-      console.log(`[MessagePushService] 检查消息: localType=${localType}, content="${content.substring(0, 50)}"`)
-
-      if (this.isAntiRevokeInjectMessage(localType, content)) {
-        // 检查撤回事件是否已推送过
-        const revokeMessageKey = `${messageKey}:revoke`
-        if (this.isRecentMessage(revokeMessageKey)) {
-          console.log(`[MessagePushService] queryAntiRevokeInSession: 撤回事件已推送过，跳过`)
-          continue
-        }
-        console.log(`[MessagePushService] queryAntiRevokeInSession: 检测到防撤回消息，立即推送`)
-        // 找到防撤回消息，立即推送
-        await this.pushAntiRevokeMessageFromMessage(sessionId, message)
-        // 推送后直接返回 true，避免同一会话的多条消息重复推送
-        return true
-      }
-    }
-    return false
-  }
-
   private extractSessionIdFromPayload(payload: Record<string, unknown> | null): string | null {
     if (!payload) {
       console.log(`[MessagePushService] extractSessionIdFromPayload: payload 为空`)
       return null
     }
 
-    // 尝试多种字段名
     const sessionId = String(
       payload.sessionId ||
       payload.talker ||
@@ -235,13 +179,11 @@ class MessagePushService {
       ''
     ).trim()
 
-    // 过滤掉明显不是 sessionId 的值
     if (!sessionId || sessionId.length < 3) {
       console.log(`[MessagePushService] extractSessionIdFromPayload: sessionId="${sessionId}" 太短或为空`)
       return null
     }
 
-    // 过滤掉数字形式的值（这通常是 localId 等）
     if (/^\d+$/.test(sessionId)) {
       console.log(`[MessagePushService] extractSessionIdFromPayload: sessionId="${sessionId}" 是纯数字`)
       return null
@@ -251,6 +193,71 @@ class MessagePushService {
     return sessionId
   }
 
+  private async handleSessionChangeForAntiRevoke(payload: Record<string, unknown> | null): Promise<void> {
+    console.log(`[MessagePushService] handleSessionChangeForAntiRevoke: Session 表变化，立即检查所有最近会话`)
+
+    const sessionsResult = await chatService.getSessions()
+    if (!sessionsResult.success || !sessionsResult.sessions || sessionsResult.sessions.length === 0) {
+      console.log(`[MessagePushService] handleSessionChangeForAntiRevoke: 无会话数据`)
+      return
+    }
+
+    const sessions = sessionsResult.sessions as ChatSession[]
+    console.log(`[MessagePushService] handleSessionChangeForAntiRevoke: 共 ${sessions.length} 个会话需要检查`)
+
+    const batchSize = 5
+    let foundCount = 0
+
+    for (let i = 0; i < sessions.length; i += batchSize) {
+      const batch = sessions.slice(i, i + batchSize)
+      const results = await Promise.all(
+        batch.map(session => this.queryAntiRevokeInSession(session.username))
+      )
+      foundCount += results.filter(Boolean).length
+    }
+
+    console.log(`[MessagePushService] handleSessionChangeForAntiRevoke: 检查完成，共发现 ${foundCount} 个会话有防撤回消息`)
+  }
+
+  private async queryAntiRevokeInSession(sessionId: string): Promise<boolean> {
+    const since = Math.floor(Date.now() / 1000) - 300
+    console.log(`[MessagePushService] queryAntiRevokeInSession: sessionId=${sessionId}, since=${since}`)
+
+    const newMessagesResult = await chatService.getNewMessages(sessionId, since, 20)
+    if (!newMessagesResult.success || !newMessagesResult.messages || newMessagesResult.messages.length === 0) {
+      console.log(`[MessagePushService] queryAntiRevokeInSession: 无新消息`)
+      return false
+    }
+
+    console.log(`[MessagePushService] queryAntiRevokeInSession: 查到 ${newMessagesResult.messages.length} 条消息`)
+
+    for (const message of newMessagesResult.messages) {
+      const messageKey = String(message.messageKey || '').trim()
+      if (!messageKey) continue
+
+      const localType = Number(message.localType || 0)
+      const content = String(message.rawContent || message.content || '').trim()
+
+      console.log(`[MessagePushService] 检查消息: localType=${localType}, content="${content.substring(0, 50)}"`)
+
+      if (this.isAntiRevokeInjectMessage(localType, content)) {
+        const revokeMessageKey = `${messageKey}:revoke`
+        if (this.isRecentMessage(revokeMessageKey)) {
+          console.log(`[MessagePushService] queryAntiRevokeInSession: 撤回事件已推送过，跳过`)
+          continue
+        }
+        if (!this.shouldPushPayload(sessionId)) {
+          console.log(`[MessagePushService] queryAntiRevokeInSession: sessionId=${sessionId} 被过滤，跳过`)
+          continue
+        }
+        console.log(`[MessagePushService] queryAntiRevokeInSession: 检测到防撤回消息，立即推送`)
+        await this.pushAntiRevokeMessageFromMessage(sessionId, message)
+        return true
+      }
+    }
+    return false
+  }
+
   private async handleMessageTableChange(payload: Record<string, unknown> | null): Promise<void> {
     if (!payload) {
       console.log(`[MessagePushService] handleMessageTableChange: payload 为空，走 debounce`)
@@ -258,33 +265,27 @@ class MessagePushService {
       return
     }
 
-    // 尝试从 payload 中提取会话信息
     const sessionId = this.extractSessionIdFromPayload(payload)
     if (!sessionId) {
       console.log(`[MessagePushService] handleMessageTableChange: 无法提取 sessionId，走 debounce`)
-      // 无法提取 sessionId，走 debounce 流程
       this.scheduleSync()
       return
     }
 
     console.log(`[MessagePushService] handleMessageTableChange: sessionId=${sessionId}`)
 
-    // 检查是否是防撤回注入的消息
     const content = String(payload.content || payload.rawContent || '').trim()
     const localType = Number(payload.localType || payload.type || 0)
     const isAntiRevokeMessage = this.isAntiRevokeInjectMessage(localType, content)
 
     if (isAntiRevokeMessage) {
-      // 防撤回消息：直接推送
       await this.pushAntiRevokeMessageDirect(sessionId, payload)
     } else {
-      // 其他消息变化：走 debounce
       this.scheduleSync()
     }
   }
 
   private isAntiRevokeInjectMessage(localType: number, content: string): boolean {
-    // localType 为 10000（系统消息）且内容包含撤回相关提示
     if (localType === 10000) {
       const normalizedContent = content.toLowerCase()
       return normalizedContent.includes('撤回') ||
@@ -295,6 +296,32 @@ class MessagePushService {
     return false
   }
 
+  private shouldPushPayload(sessionId: string): boolean {
+    const filterMode = this.getMessagePushFilterMode()
+    if (filterMode === 'all') {
+      return true
+    }
+
+    const filterList = this.getMessagePushFilterList()
+    const listed = filterList.has(sessionId)
+    if (filterMode === 'whitelist') {
+      return listed
+    }
+    return !listed
+  }
+
+  private getMessagePushFilterMode(): 'all' | 'whitelist' | 'blacklist' {
+    const value = this.configService.get('messagePushFilterMode')
+    if (value === 'whitelist' || value === 'blacklist') return value
+    return 'all'
+  }
+
+  private getMessagePushFilterList(): Set<string> {
+    const value = this.configService.get('messagePushFilterList')
+    if (!Array.isArray(value)) return new Set()
+    return new Set(value.map((item) => String(item || '').trim()).filter(Boolean))
+  }
+
   private async pushAntiRevokeMessageFromMessage(sessionId: string, message: Message): Promise<void> {
     const messageKey = String(message.messageKey || '').trim()
     if (!messageKey) {
@@ -302,122 +329,98 @@ class MessagePushService {
       return
     }
 
-    // 为撤回事件生成唯一的 messageKey，避免与被撤回消息的 messageKey 冲突
     const revokeMessageKey = `${messageKey}:revoke`
     const content = String(message.parsedContent || message.rawContent || '[系统消息]').trim()
     const serverId = message.serverId ? String(message.serverId) : undefined
+    const sessionType = this.getSessionTypeFromId(sessionId)
 
     console.log(`[MessagePushService] pushAntiRevokeMessageFromMessage: 准备推送撤回事件, messageKey=${messageKey}, revokeMessageKey=${revokeMessageKey}`)
-
-    // 立即构建 payload，使用缓存的会话信息
-    const isGroup = sessionId.endsWith('@chatroom')
-    const cachedSession = this.getCachedSession(sessionId)
-    const session = cachedSession || undefined
-
-    let sourceName = session?.displayName || sessionId
-    let avatarUrl = session?.avatarUrl
-
-    if (!session) {
-      // 异步获取会话信息并缓存
-      this.refreshSessionInfoCache(sessionId)
-    }
 
     const revokePayload: MessageRevokePayload = {
       event: 'message.revoke',
       sessionId,
+      sessionType,
       messageKey: revokeMessageKey,
-      avatarUrl,
-      sourceName,
-      groupName: isGroup ? (session?.displayName || sessionId) : undefined,
+      avatarUrl: undefined,
+      sourceName: sessionId,
+      groupName: sessionId.endsWith('@chatroom') ? sessionId : undefined,
       content,
       originalServerId: serverId
     }
 
     console.log(`[MessagePushService] pushAntiRevokeMessageFromMessage: 调用 broadcastMessagePush`)
-    // 立即推送，不等待异步会话信息获取
     httpService.broadcastMessagePush(revokePayload as unknown as Record<string, unknown>)
     this.rememberMessageKey(revokeMessageKey)
     console.log(`[MessagePushService] pushAntiRevokeMessageFromMessage: broadcastMessagePush 完成`)
   }
 
-  private getCachedSession(sessionId: string): ChatSession | null {
-    const cached = this.sessionInfoCache.get(sessionId)
-    if (cached && Date.now() - cached.updatedAt < this.sessionInfoCacheTtlMs) {
-      return cached.session
-    }
-    return null
-  }
-
-  private async refreshSessionInfoCache(sessionId: string): Promise<void> {
-    try {
-      const sessionsResult = await chatService.getSessions()
-      if (sessionsResult.success && sessionsResult.sessions) {
-        const session = (sessionsResult.sessions as ChatSession[]).find(s => s.username === sessionId)
-        this.sessionInfoCache.set(sessionId, { session: session || null, updatedAt: Date.now() })
-      }
-    } catch {
-      // 忽略错误
-    }
-  }
-
   private async pushAntiRevokeMessageDirect(sessionId: string, payload: Record<string, unknown>): Promise<void> {
     const baseMessageKey = String(payload.messageKey || payload.key || `${sessionId}_${payload.localId || payload.id || Date.now()}`).trim()
-    // 为撤回事件生成唯一的 messageKey
     const revokeMessageKey = `${baseMessageKey}:revoke`
 
-    // 检查撤回事件是否已经推送过
     if (this.isRecentMessage(revokeMessageKey)) {
+      return
+    }
+
+    if (!this.shouldPushPayload(sessionId)) {
+      console.log(`[MessagePushService] pushAntiRevokeMessageDirect: sessionId=${sessionId} 被过滤，跳过推送`)
       return
     }
 
     const content = String(payload.content || payload.rawContent || '[系统消息]').trim()
     const serverId = payload.serverId ? String(payload.serverId) : undefined
+    const sessionType = this.getSessionTypeFromId(sessionId)
     const isGroup = sessionId.endsWith('@chatroom')
 
-    // 获取会话信息
-    const sessionsResult = await chatService.getSessions()
-    if (!sessionsResult.success || !sessionsResult.sessions) {
-      return
-    }
-
-    const session = (sessionsResult.sessions as ChatSession[]).find(s => s.username === sessionId)
-
-    let sourceName: string
+    let sourceName = sessionId
     let avatarUrl: string | undefined
 
-    if (session) {
-      if (isGroup) {
-        const groupInfo = await chatService.getContactAvatar(sessionId)
-        avatarUrl = session.avatarUrl || groupInfo?.avatarUrl
-        sourceName = session.displayName || groupInfo?.displayName || sessionId
+    const sessionsResult = await chatService.getSessions()
+    if (sessionsResult.success && sessionsResult.sessions) {
+      const session = (sessionsResult.sessions as ChatSession[]).find(s => s.username === sessionId)
+      if (session) {
+        if (isGroup) {
+          const groupInfo = await chatService.getContactAvatar(sessionId)
+          avatarUrl = session.avatarUrl || groupInfo?.avatarUrl
+          sourceName = session.displayName || groupInfo?.displayName || sessionId
+        } else {
+          const contactInfo = await chatService.getContactAvatar(sessionId)
+          avatarUrl = session.avatarUrl || contactInfo?.avatarUrl
+          sourceName = session.displayName || contactInfo?.displayName || sessionId
+        }
       } else {
-        const contactInfo = await chatService.getContactAvatar(sessionId)
-        avatarUrl = session.avatarUrl || contactInfo?.avatarUrl
-        sourceName = session.displayName || contactInfo?.displayName || sessionId
-      }
-    } else {
-      if (isGroup) {
-        sourceName = sessionId
-      } else {
-        const contactInfo = await chatService.getContactAvatar(sessionId)
-        avatarUrl = contactInfo?.avatarUrl
-        sourceName = contactInfo?.displayName || sessionId
+        if (isGroup) {
+          const groupInfo = await chatService.getContactAvatar(sessionId)
+          avatarUrl = groupInfo?.avatarUrl
+          sourceName = groupInfo?.displayName || sessionId
+        } else {
+          const contactInfo = await chatService.getContactAvatar(sessionId)
+          avatarUrl = contactInfo?.avatarUrl
+          sourceName = contactInfo?.displayName || sessionId
+        }
       }
     }
 
     const revokePayload: MessageRevokePayload = {
       event: 'message.revoke',
       sessionId,
+      sessionType,
       messageKey: revokeMessageKey,
       avatarUrl,
       sourceName,
-      groupName: isGroup ? (session?.displayName || sessionId) : undefined,
+      groupName: isGroup ? sourceName : undefined,
       content,
       originalServerId: serverId
     }
 
     httpService.broadcastMessagePush(revokePayload as unknown as Record<string, unknown>)
     this.rememberMessageKey(revokeMessageKey)
+  }
+
+  private getSessionTypeFromId(sessionId: string): MessagePushPayload['sessionType'] {
+    if (sessionId.endsWith('@chatroom')) return 'group'
+    if (sessionId.startsWith('gh_')) return 'official'
+    return 'other'
   }
 
   async handleConfigChanged(key: string): Promise<void> {
@@ -442,7 +445,6 @@ class MessagePushService {
     this.sessionBaseline.clear()
     this.recentMessageKeys.clear()
     this.groupNicknameCache.clear()
-    this.sessionInfoCache.clear()
     this.baselineReady = false
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer)
@@ -561,12 +563,10 @@ class MessagePushService {
       return false
     }
 
-    // unread 未增长时，大概率是自己发送、其他设备已读或状态同步，不作为主动推送
     return unreadCount > previous.unreadCount
   }
 
   private async pushSessionMessages(session: ChatSession, previous: SessionBaseline | undefined): Promise<void> {
-    // 如果没有 baseline，只查询程序启动后的消息，避免推送历史消息
     const since = previous ? Math.max(0, Number(previous.lastTimestamp || 0) - 1) : this.appStartTime
     const newMessagesResult = await chatService.getNewMessages(session.username, since, 1000)
     if (!newMessagesResult.success || !newMessagesResult.messages || newMessagesResult.messages.length === 0) {
@@ -582,26 +582,29 @@ class MessagePushService {
         continue
       }
 
-      // 无论如何，只推送程序启动后的消息
       if (Number(message.createTime || 0) < this.appStartTime) {
         continue
       }
 
-      // 检查是否是防撤回注入的消息
       const localType = Number(message.localType || 0)
       const content = String(message.rawContent || message.content || '').trim()
       if (this.isAntiRevokeInjectMessage(localType, content)) {
-        // 检查撤回事件是否已推送过
         const revokeMessageKey = `${messageKey}:revoke`
         if (this.isRecentMessage(revokeMessageKey)) {
           continue
         }
-        // 推送撤回事件
+        if (!this.shouldPushPayload(session.username)) {
+          continue
+        }
         void this.pushAntiRevokeMessageFromMessage(session.username, message)
         continue
       }
 
       if (this.isRecentMessage(messageKey)) {
+        continue
+      }
+
+      if (!this.shouldPushPayload(session.username)) {
         continue
       }
 
@@ -619,6 +622,7 @@ class MessagePushService {
     if (!sessionId || !messageKey) return null
 
     const isGroup = sessionId.endsWith('@chatroom')
+    const sessionType = this.getSessionTypeFromId(sessionId)
     const content = this.getMessageDisplayContent(message)
     const isEmoji = Number(message.localType || 0) === 47
     const emojiMd5 = isEmoji ? (message.emojiMd5 || undefined) : undefined
@@ -627,11 +631,13 @@ class MessagePushService {
       const groupInfo = await chatService.getContactAvatar(sessionId)
       const groupName = session.displayName || groupInfo?.displayName || sessionId
       const sourceName = await this.resolveGroupSourceName(sessionId, message, session)
+      const avatarUrl = await this.normalizePushAvatarUrl(session.avatarUrl || groupInfo?.avatarUrl)
       return {
         event: 'message.new',
         sessionId,
+        sessionType,
         messageKey,
-        avatarUrl: session.avatarUrl || groupInfo?.avatarUrl,
+        avatarUrl,
         groupName,
         sourceName,
         content,
@@ -640,15 +646,62 @@ class MessagePushService {
     }
 
     const contactInfo = await chatService.getContactAvatar(sessionId)
+    const avatarUrl = await this.normalizePushAvatarUrl(session.avatarUrl || contactInfo?.avatarUrl)
     return {
       event: 'message.new',
       sessionId,
+      sessionType,
       messageKey,
-      avatarUrl: session.avatarUrl || contactInfo?.avatarUrl,
+      avatarUrl,
       sourceName: session.displayName || contactInfo?.displayName || sessionId,
       content,
       emojiMd5
     }
+  }
+
+  private async normalizePushAvatarUrl(avatarUrl?: string): Promise<string | undefined> {
+    const normalized = String(avatarUrl || '').trim()
+    if (!normalized) return undefined
+    if (!normalized.startsWith('data:image/')) {
+      return normalized || undefined
+    }
+
+    const cached = this.pushAvatarDataCache.get(normalized)
+    if (cached) return cached
+
+    const match = /^data:(image\/[a-zA-Z0-9.+-]+);base64,(.+)$/i.exec(normalized)
+    if (!match) return undefined
+
+    try {
+      const mimeType = match[1].toLowerCase()
+      const base64Data = match[2]
+      const imageBuffer = Buffer.from(base64Data, 'base64')
+      if (!imageBuffer.length) return undefined
+
+      const ext = this.getImageExtFromMime(mimeType)
+      const hash = createHash('sha1').update(normalized).digest('hex')
+      const filePath = path.join(this.pushAvatarCacheDir, `avatar_${hash}.${ext}`)
+
+      await fs.mkdir(this.pushAvatarCacheDir, { recursive: true })
+      try {
+        await fs.access(filePath)
+      } catch {
+        await fs.writeFile(filePath, imageBuffer)
+      }
+
+      const fileUrl = pathToFileURL(filePath).toString()
+      this.pushAvatarDataCache.set(normalized, fileUrl)
+      return fileUrl
+    } catch {
+      return undefined
+    }
+  }
+
+  private getImageExtFromMime(mimeType: string): string {
+    if (mimeType === 'image/png') return 'png'
+    if (mimeType === 'image/gif') return 'gif'
+    if (mimeType === 'image/webp') return 'webp'
+    return 'jpg'
   }
 
   private getMessageDisplayContent(message: Message): string | null {

--- a/electron/services/messagePushService.ts
+++ b/electron/services/messagePushService.ts
@@ -49,13 +49,13 @@ class MessagePushService {
   private readonly configService: ConfigService
   private readonly sessionBaseline = new Map<string, SessionBaseline>()
   private readonly recentMessageKeys = new Map<string, number>()
+  private readonly revokedServerIds = new Set<string>()
   private readonly groupNicknameCache = new Map<string, { nicknames: Record<string, string>; updatedAt: number }>()
   private readonly pushAvatarCacheDir: string
   private readonly pushAvatarDataCache = new Map<string, string>()
   private readonly debounceMs = 350
   private readonly recentMessageTtlMs = 10 * 60 * 1000
   private readonly groupNicknameCacheTtlMs = 5 * 60 * 1000
-  private readonly appStartTime = Math.floor(Date.now() / 1000)
   private debounceTimer: ReturnType<typeof setTimeout> | null = null
   private processing = false
   private rerunRequested = false
@@ -65,6 +65,10 @@ class MessagePushService {
   constructor() {
     this.configService = ConfigService.getInstance()
     this.pushAvatarCacheDir = path.join(this.configService.getCacheBasePath(), 'push-avatar-files')
+  }
+
+  private getSseConnectedAt(): number {
+    return httpService.getMessagePushConnectedAt()
   }
 
   start(): void {
@@ -117,12 +121,15 @@ class MessagePushService {
     // 兜底：如果 payload 中包含消息相关的字段（localType、content、localId 等），
     // 说明是消息表变化，尝试提取 sessionId 并检测防撤回
     if (payload && this.hasMessageFields(payload)) {
-      console.log(`[MessagePushService] hasMessageFields=true, payload: ${JSON.stringify(payload)}`)
-      const sessionId = this.extractSessionIdFromPayload(payload)
-      console.log(`[MessagePushService] hasMessageFields=true, sessionId=${sessionId}`)
-      if (sessionId) {
-        console.log(`[MessagePushService] 调用 handleSessionChangeForAntiRevoke (兜底路径)`)
-        void this.handleSessionChangeForAntiRevoke(payload)
+      const sessionIds = chatService.collectSessionIdsFromPayload(payload)
+      console.log(`[MessagePushService] hasMessageFields=true，提取到 ${sessionIds.size} 个 sessionId`)
+      if (sessionIds.size > 0) {
+        // 精确检测受影响的会话
+        void (async () => {
+          const results = await Promise.all([...sessionIds].map(sessionId => this.queryAntiRevokeInSession(sessionId)))
+          const foundCount = results.filter(Boolean).length
+          console.log(`[MessagePushService] 兜底防撤回检测完成，共 ${foundCount} 个会话有防撤回消息`)
+        })()
       }
       this.scheduleSync()
       return
@@ -157,44 +164,21 @@ class MessagePushService {
            normalized === 'msgqueue'
   }
 
-  private extractSessionIdFromPayload(payload: Record<string, unknown> | null): string | null {
-    if (!payload) {
-      console.log(`[MessagePushService] extractSessionIdFromPayload: payload 为空`)
-      return null
-    }
-
-    const sessionId = String(
-      payload.sessionId ||
-      payload.talker ||
-      payload.username ||
-      payload.susername ||
-      payload.wxid ||
-      payload.fromUsername ||
-      payload.toUsername ||
-      payload.from ||
-      payload.to ||
-      payload.chatName ||
-      payload.chatId ||
-      payload.conversationId ||
-      ''
-    ).trim()
-
-    if (!sessionId || sessionId.length < 3) {
-      console.log(`[MessagePushService] extractSessionIdFromPayload: sessionId="${sessionId}" 太短或为空`)
-      return null
-    }
-
-    if (/^\d+$/.test(sessionId)) {
-      console.log(`[MessagePushService] extractSessionIdFromPayload: sessionId="${sessionId}" 是纯数字`)
-      return null
-    }
-
-    console.log(`[MessagePushService] extractSessionIdFromPayload: 提取到 sessionId="${sessionId}"`)
-    return sessionId
-  }
-
   private async handleSessionChangeForAntiRevoke(payload: Record<string, unknown> | null): Promise<void> {
-    console.log(`[MessagePushService] handleSessionChangeForAntiRevoke: Session 表变化，立即检查所有最近会话`)
+    // 先尝试从 payload 中精确提取受影响的会话 ID，避免全量扫描
+    if (payload) {
+      const sessionIds = chatService.collectSessionIdsFromPayload(payload)
+      if (sessionIds.size > 0) {
+        console.log(`[MessagePushService] handleSessionChangeForAntiRevoke: 精确检测 ${sessionIds.size} 个会话: ${[...sessionIds].join(', ')}`)
+        const results = await Promise.all([...sessionIds].map(sessionId => this.queryAntiRevokeInSession(sessionId)))
+        const foundCount = results.filter(Boolean).length
+        console.log(`[MessagePushService] handleSessionChangeForAntiRevoke: 完成，共 ${foundCount} 个会话有防撤回消息`)
+        return
+      }
+    }
+
+    // 无法精确提取时，退化为全量扫描（仅在确实需要时）
+    console.log(`[MessagePushService] handleSessionChangeForAntiRevoke: 无法精确提取，退化为全量扫描`)
 
     const sessionsResult = await chatService.getSessions()
     if (!sessionsResult.success || !sessionsResult.sessions || sessionsResult.sessions.length === 0) {
@@ -231,12 +215,20 @@ class MessagePushService {
 
     console.log(`[MessagePushService] queryAntiRevokeInSession: 查到 ${newMessagesResult.messages.length} 条消息`)
 
+    const sseConnectedAt = this.getSseConnectedAt()
+
     for (const message of newMessagesResult.messages) {
       const messageKey = String(message.messageKey || '').trim()
       if (!messageKey) continue
 
       const localType = Number(message.localType || 0)
       const content = String(message.rawContent || message.content || '').trim()
+      const createTime = Number(message.createTime || 0)
+
+      // SSE 连接前的历史撤回不推送
+      if (sseConnectedAt > 0 && createTime < sseConnectedAt) {
+        continue
+      }
 
       console.log(`[MessagePushService] 检查消息: localType=${localType}, content="${content.substring(0, 50)}"`)
 
@@ -265,21 +257,21 @@ class MessagePushService {
       return
     }
 
-    const sessionId = this.extractSessionIdFromPayload(payload)
-    if (!sessionId) {
+    const sessionIds = chatService.collectSessionIdsFromPayload(payload)
+    if (sessionIds.size === 0) {
       console.log(`[MessagePushService] handleMessageTableChange: 无法提取 sessionId，走 debounce`)
       this.scheduleSync()
       return
     }
-
-    console.log(`[MessagePushService] handleMessageTableChange: sessionId=${sessionId}`)
 
     const content = String(payload.content || payload.rawContent || '').trim()
     const localType = Number(payload.localType || payload.type || 0)
     const isAntiRevokeMessage = this.isAntiRevokeInjectMessage(localType, content)
 
     if (isAntiRevokeMessage) {
-      await this.pushAntiRevokeMessageDirect(sessionId, payload)
+      for (const sessionId of sessionIds) {
+        await this.pushAntiRevokeMessageDirect(sessionId, payload)
+      }
     } else {
       this.scheduleSync()
     }
@@ -334,6 +326,11 @@ class MessagePushService {
     const serverId = message.serverId ? String(message.serverId) : undefined
     const sessionType = this.getSessionTypeFromId(sessionId)
 
+    if (!this.shouldPushPayload(sessionId)) {
+      console.log(`[MessagePushService] pushAntiRevokeMessageFromMessage: sessionId=${sessionId} 被过滤，跳过`)
+      return
+    }
+
     console.log(`[MessagePushService] pushAntiRevokeMessageFromMessage: 准备推送撤回事件, messageKey=${messageKey}, revokeMessageKey=${revokeMessageKey}`)
 
     const revokePayload: MessageRevokePayload = {
@@ -351,6 +348,9 @@ class MessagePushService {
     console.log(`[MessagePushService] pushAntiRevokeMessageFromMessage: 调用 broadcastMessagePush`)
     httpService.broadcastMessagePush(revokePayload as unknown as Record<string, unknown>)
     this.rememberMessageKey(revokeMessageKey)
+    if (serverId) {
+      this.revokedServerIds.add(serverId)
+    }
     console.log(`[MessagePushService] pushAntiRevokeMessageFromMessage: broadcastMessagePush 完成`)
   }
 
@@ -415,6 +415,9 @@ class MessagePushService {
 
     httpService.broadcastMessagePush(revokePayload as unknown as Record<string, unknown>)
     this.rememberMessageKey(revokeMessageKey)
+    if (serverId) {
+      this.revokedServerIds.add(serverId)
+    }
   }
 
   private getSessionTypeFromId(sessionId: string): MessagePushPayload['sessionType'] {
@@ -444,6 +447,7 @@ class MessagePushService {
   private resetRuntimeState(): void {
     this.sessionBaseline.clear()
     this.recentMessageKeys.clear()
+    this.revokedServerIds.clear()
     this.groupNicknameCache.clear()
     this.baselineReady = false
     if (this.debounceTimer) {
@@ -567,7 +571,12 @@ class MessagePushService {
   }
 
   private async pushSessionMessages(session: ChatSession, previous: SessionBaseline | undefined): Promise<void> {
-    const since = previous ? Math.max(0, Number(previous.lastTimestamp || 0) - 1) : this.appStartTime
+    const sseConnectedAt = this.getSseConnectedAt()
+    // SSE 未连接时（sseConnectedAt === 0），不推送任何消息
+    if (sseConnectedAt === 0) {
+      return
+    }
+    const since = previous ? Math.max(0, Number(previous.lastTimestamp || 0) - 1) : sseConnectedAt
     const newMessagesResult = await chatService.getNewMessages(session.username, since, 1000)
     if (!newMessagesResult.success || !newMessagesResult.messages || newMessagesResult.messages.length === 0) {
       return
@@ -582,7 +591,14 @@ class MessagePushService {
         continue
       }
 
-      if (Number(message.createTime || 0) < this.appStartTime) {
+      // SSE 连接前的历史消息不推送
+      if (Number(message.createTime || 0) < sseConnectedAt) {
+        continue
+      }
+
+      // 已被撤回的消息（防撤回注入后，原消息仍在 DB 中）不推送
+      const serverId = message.serverId ? String(message.serverId) : undefined
+      if (serverId && this.revokedServerIds.has(serverId)) {
         continue
       }
 


### PR DESCRIPTION
本次提交全面修复了消息推送服务中的防撤回功能、性能瓶颈及配置回归问题。

**核心修复与优化**

1. **性能优化：消除全量扫描**
   - **问题**：`session` 表变更时，原逻辑无条件执行全量会话扫描，造成巨大性能开销。
   - **修复**：优先调用 `chatService.collectSessionIdsFromPayload()` 精确提取受影响的会话 ID，仅对目标会话进行防撤回检测；仅在提取失败时退化为全量扫描。
   - **改进**：统一了 `handleMessageTableChange` 及兜底路径的会话提取逻辑，删除了冗余的 `extractSessionIdFromPayload` 方法。

2. **功能回归：修复推送黑白名单**
   - **问题**：`PUSH_CONFIG_KEYS` 中移除了 `messagePushFilterMode` 和 `messagePushFilterList`，导致 UI 配置失效，用户收到所有推送。
   - **修复**：恢复配置监听，并在 `queryAntiRevokeInSession`、`pushAntiRevokeMessageFromMessage` 及 `pushAntiRevokeMessageDirect` 三处关键路径中重新引入 `shouldPushPayload()` 过滤逻辑，确保与设置页 UI 保持一致。

3. **逻辑完善：防止消息重复推送**
   - **新增机制**：引入 `revokedServerIds` 集合追踪已处理的撤回消息。
   - **效果**：在 `pushSessionMessages` 中自动跳过已被防撤回机制处理过的原始消息，避免同一内容的重复通知。
   - **SSE 重连保护**：引入 `messagePushConnectedAt` 时间戳，确保仅推送连接建立后产生的新事件，防止重连时的历史消息风暴。

**其他改进**
- **Payload 补全**：修复并补回了 `sessionType` 和 `emojiMd5` 字段，确保客户端展示正确。
- **代码清理**：移除了未使用的 `appStartTime` 和 `sessionInfoCache`，公开 `collectSessionIdsFromPayload` 供外部复用。