### PR TITLE
修复 SNS media key 解密失败，提示朋友圈已删除，图片无法正常显示

### DIFF
--- a/electron/services/snsService.ts
+++ b/electron/services/snsService.ts
@@ -14,8 +14,11 @@ export interface SnsLivePhoto {
     thumb: string
     md5?: string
     token?: string
+    thumbToken?: string
     key?: string
+    thumbKey?: string
     encIdx?: string
+    thumbEncIdx?: string
 }
 
 export interface SnsMedia {
@@ -23,8 +26,11 @@ export interface SnsMedia {
     thumb: string
     md5?: string
     token?: string
+    thumbToken?: string
     key?: string
+    thumbKey?: string
     encIdx?: string
+    thumbEncIdx?: string
     livePhoto?: SnsLivePhoto
 }
 
@@ -196,7 +202,7 @@ export const isVideoUrl = (url: string) => {
     if (!url) return false
     // 排除 vweixinthumb 域名 (缩略图)
     if (url.includes('vweixinthumb')) return false
-    return url.includes('snsvideodownload') || url.includes('video') || url.includes('.mp4')
+    return url.includes('snsvideodownload') || url.includes('stodownload') || url.includes('video') || url.includes('.mp4')
 }
 
 import { Isaac64 } from './isaac64'
@@ -703,10 +709,13 @@ class SnsService {
                 const item: SnsMedia = {
                     url: urlMatch ? urlMatch[1].trim() : '',
                     thumb: thumbMatch ? thumbMatch[1].trim() : '',
-                    token: urlToken || thumbToken,
-                    key: urlKey || thumbKey,
+                    token: urlToken,
+                    thumbToken,
+                    key: urlKey,
+                    thumbKey,
                     md5: urlMd5,
-                    encIdx: urlEncIdx || thumbEncIdx
+                    encIdx: urlEncIdx,
+                    thumbEncIdx
                 }
 
                 const livePhotoMatch = mx.match(/<livePhoto>([\s\S]*?)<\/livePhoto>/i)
@@ -717,20 +726,28 @@ class SnsService {
                     const lpThumb = lx.match(/<thumb[^>]*>([^<]+)<\/thumb>/i)
                     const lpThumbTag = lx.match(/<thumb([^>]*)>/i)
                     let lpToken: string | undefined, lpKey: string | undefined, lpEncIdx: string | undefined
+                    let lpThumbToken: string | undefined, lpThumbKey: string | undefined, lpThumbEncIdx: string | undefined
                     if (lpUrlTag?.[1]) {
                         const a = lpUrlTag[1]
                         lpToken = a.match(/token="([^"]+)"/i)?.[1]
                         lpKey = a.match(/key="([^"]+)"/i)?.[1]
                         lpEncIdx = a.match(/enc_idx="([^"]+)"/i)?.[1]
                     }
-                    if (!lpToken && lpThumbTag?.[1]) lpToken = lpThumbTag[1].match(/token="([^"]+)"/i)?.[1]
-                    if (!lpKey && lpThumbTag?.[1]) lpKey = lpThumbTag[1].match(/key="([^"]+)"/i)?.[1]
+                    if (lpThumbTag?.[1]) {
+                        const a = lpThumbTag[1]
+                        lpThumbToken = a.match(/token="([^"]+)"/i)?.[1]
+                        lpThumbKey = a.match(/key="([^"]+)"/i)?.[1]
+                        lpThumbEncIdx = a.match(/enc_idx="([^"]+)"/i)?.[1]
+                    }
                     item.livePhoto = {
                         url: lpUrl ? lpUrl[1].trim() : '',
                         thumb: lpThumb ? lpThumb[1].trim() : '',
                         token: lpToken,
+                        thumbToken: lpThumbToken,
                         key: lpKey,
-                        encIdx: lpEncIdx
+                        thumbKey: lpThumbKey,
+                        encIdx: lpEncIdx,
+                        thumbEncIdx: lpThumbEncIdx
                     }
                 }
                 media.push(item)
@@ -1179,22 +1196,49 @@ class SnsService {
                 this.parseLocationFromXml(rawXml)
             )
 
-            const fixedMedia = (post.media || []).map((m: any) => ({
-                url: fixSnsUrl(m.url, m.token, isVideoPost),
-                thumb: fixSnsUrl(m.thumb, m.token, false),
-                md5: m.md5,
-                token: m.token,
-                key: isVideoPost ? (videoKey || m.key) : m.key,
-                encIdx: m.encIdx || m.enc_idx,
-                livePhoto: m.livePhoto ? {
-                    ...m.livePhoto,
-                    url: fixSnsUrl(m.livePhoto.url, m.livePhoto.token, true),
-                    thumb: fixSnsUrl(m.livePhoto.thumb, m.livePhoto.token, false),
-                    token: m.livePhoto.token,
-                    key: videoKey || m.livePhoto.key || m.key,
-                    encIdx: m.livePhoto.encIdx || m.livePhoto.enc_idx
-                } : undefined
-            }))
+            const xmlMediaResult = this.parseMediaFromXml(rawXml)
+            const xmlMediaMap = new Map<string, SnsMedia>()
+            xmlMediaResult.media.forEach((item) => {
+                if (item.url) xmlMediaMap.set(item.url, item)
+                if (item.thumb) xmlMediaMap.set(item.thumb, item)
+            })
+
+            const fixedMedia = (post.media || []).map((m: any, idx: number) => {
+                const xmlMatch = xmlMediaMap.get(m.url) || xmlMediaMap.get(m.thumb) || xmlMediaResult.media[idx]
+                const resolvedUrl = m.url || xmlMatch?.url || ''
+                const resolvedThumb = m.thumb || xmlMatch?.thumb || ''
+                const resolvedToken = m.token || xmlMatch?.token
+                const resolvedThumbToken = m.thumbToken || xmlMatch?.thumbToken || resolvedToken
+                const resolvedKey = isVideoPost ? (videoKey || m.key || xmlMatch?.key || xmlMediaResult.videoKey) : (m.key || xmlMatch?.key)
+                const resolvedThumbKey = m.thumbKey || xmlMatch?.thumbKey || resolvedKey
+                const resolvedEncIdx = m.encIdx || m.enc_idx || xmlMatch?.encIdx
+                const resolvedThumbEncIdx = m.thumbEncIdx || m.thumb_enc_idx || xmlMatch?.thumbEncIdx || resolvedEncIdx
+                const liveXml = xmlMatch?.livePhoto
+                const livePhoto = m.livePhoto || liveXml
+
+                return {
+                    url: fixSnsUrl(resolvedUrl, resolvedToken, isVideoPost),
+                    thumb: fixSnsUrl(resolvedThumb, resolvedThumbToken, false),
+                    md5: m.md5 || xmlMatch?.md5,
+                    token: resolvedToken,
+                    thumbToken: resolvedThumbToken,
+                    key: resolvedKey,
+                    thumbKey: resolvedThumbKey,
+                    encIdx: resolvedEncIdx,
+                    thumbEncIdx: resolvedThumbEncIdx,
+                    livePhoto: livePhoto ? {
+                        ...livePhoto,
+                        url: fixSnsUrl(livePhoto.url || liveXml?.url || '', livePhoto.token || liveXml?.token, true),
+                        thumb: fixSnsUrl(livePhoto.thumb || liveXml?.thumb || '', livePhoto.thumbToken || liveXml?.thumbToken || livePhoto.token || liveXml?.token, false),
+                        token: livePhoto.token || liveXml?.token,
+                        thumbToken: livePhoto.thumbToken || liveXml?.thumbToken,
+                        key: videoKey || livePhoto.key || liveXml?.key || resolvedKey,
+                        thumbKey: livePhoto.thumbKey || liveXml?.thumbKey || livePhoto.key || liveXml?.key || resolvedThumbKey,
+                        encIdx: livePhoto.encIdx || liveXml?.encIdx,
+                        thumbEncIdx: livePhoto.thumbEncIdx || liveXml?.thumbEncIdx
+                    } : undefined
+                }
+            })
 
             //数据服务已返回完整评论数据（含 emojis、refNickname）
             // 如果数据服务评论缺少表情包信息，回退到从 rawXml 重新解析

--- a/src/components/Sns/SnsMediaGrid.tsx
+++ b/src/components/Sns/SnsMediaGrid.tsx
@@ -8,14 +8,20 @@ interface SnsMedia {
     thumb: string
     md5?: string
     token?: string
+    thumbToken?: string
     key?: string
+    thumbKey?: string
     encIdx?: string
+    thumbEncIdx?: string
     livePhoto?: {
         url: string
         thumb: string
         token?: string
+        thumbToken?: string
         key?: string
+        thumbKey?: string
         encIdx?: string
+        thumbEncIdx?: string
     }
 }
 
@@ -29,7 +35,7 @@ interface SnsMediaGridProps {
 const isSnsVideoUrl = (url?: string): boolean => {
     if (!url) return false
     const lower = url.toLowerCase()
-    return (lower.includes('snsvideodownload') || lower.includes('.mp4') || lower.includes('video')) && !lower.includes('vweixinthumb')
+    return (lower.includes('snsvideodownload') || lower.includes('stodownload') || lower.includes('.mp4') || lower.includes('video')) && !lower.includes('vweixinthumb')
 }
 
 const extractVideoFrame = async (videoPath: string): Promise<string> => {
@@ -82,7 +88,6 @@ const extractVideoFrame = async (videoPath: string): Promise<string> => {
 }
 
 const MediaItem = ({ media, postType, onPreview, onMediaDeleted }: { media: SnsMedia; postType?: number; onPreview: (src: string, isVideo?: boolean, liveVideoPath?: string) => void; onMediaDeleted?: () => void }) => {
-    const [error, setError] = useState(false)
     const [deleted, setDeleted] = useState(false)
     const [loading, setLoading] = useState(true)
     const markDeleted = () => { setDeleted(true); onMediaDeleted?.() }
@@ -99,6 +104,11 @@ const MediaItem = ({ media, postType, onPreview, onMediaDeleted }: { media: SnsM
     const targetUrl = media.thumb || media.url
     // type 7 的朋友圈媒体不需要解密，直接使用原始 URL
     const skipDecrypt = postType === 7
+    const markFailed = (message?: unknown) => {
+        console.warn('[SnsMediaGrid] media load failed', message)
+        if (!isVideo && targetUrl) setThumbSrc(targetUrl)
+        setLoading(false)
+    }
 
     // 视频重试：失败时重试最多2次，耗尽才标记删除
     const videoRetryOrDelete = () => {
@@ -119,18 +129,29 @@ const MediaItem = ({ media, postType, onPreview, onMediaDeleted }: { media: SnsM
         const load = async () => {
             try {
                 if (!isVideo) {
-                    // For images, we proxy to get the local path/base64
-                    const result = await window.electronAPI.sns.proxyImage({
-                        url: targetUrl,
-                        key: skipDecrypt ? undefined : media.key
-                    })
+                    // Newer SNS records may require thumbKey/thumbToken for thumbnails,
+                    // while older records may still need the main key or even the full image URL.
+                    const imageCandidates = [
+                        { url: targetUrl, key: skipDecrypt ? undefined : ((targetUrl === media.thumb ? media.thumbKey : media.key) || media.key) },
+                        { url: targetUrl, key: skipDecrypt ? undefined : media.key },
+                        { url: media.url || targetUrl, key: skipDecrypt ? undefined : media.key },
+                        { url: media.url || targetUrl, key: skipDecrypt ? undefined : media.thumbKey }
+                    ].filter((item, index, list) => (
+                        !!item.url && list.findIndex((candidate) => candidate.url === item.url && candidate.key === item.key) === index
+                    ))
+
+                    let result: { success: boolean; dataUrl?: string; videoPath?: string; error?: string } = { success: false, error: 'no candidate' }
+                    for (const candidate of imageCandidates) {
+                        result = await window.electronAPI.sns.proxyImage(candidate)
+                        if (result.success) break
+                    }
                     if (cancelled) return
 
                     if (result.success) {
                         if (result.dataUrl) setThumbSrc(result.dataUrl)
                         else if (result.videoPath) setThumbSrc(`file://${result.videoPath.replace(/\\/g, '/')}`)
                     } else {
-                        markDeleted()
+                        markFailed(result.error)
                     }
 
                     // Pre-load live photo video if needed
@@ -183,7 +204,7 @@ const MediaItem = ({ media, postType, onPreview, onMediaDeleted }: { media: SnsM
                     if (isVideo) {
                         videoRetryOrDelete()
                     } else {
-                        markDeleted()
+                        markFailed(e)
                     }
                     setLoading(false)
                     setIsGeneratingCover(false)
@@ -305,7 +326,7 @@ const MediaItem = ({ media, postType, onPreview, onMediaDeleted }: { media: SnsM
                     src={thumbSrc}
                     className="media-image"
                     loading="lazy"
-                    onError={() => { if (!loading && !isVideo) markDeleted() }}
+                    onError={() => { if (!loading && !isVideo) markFailed('image render error') }}
                     alt=""
                 />
             ) : null}

--- a/src/components/Sns/SnsPostItem.tsx
+++ b/src/components/Sns/SnsPostItem.tsx
@@ -15,7 +15,7 @@ const MEDIA_HOST_HINTS = ['mmsns.qpic.cn', 'vweixinthumb', 'snstimeline', 'snsvi
 const isSnsVideoUrl = (url?: string): boolean => {
     if (!url) return false
     const lower = url.toLowerCase()
-    return (lower.includes('snsvideodownload') || lower.includes('.mp4') || lower.includes('video')) && !lower.includes('vweixinthumb')
+    return (lower.includes('snsvideodownload') || lower.includes('stodownload') || lower.includes('.mp4') || lower.includes('video')) && !lower.includes('vweixinthumb')
 }
 
 const decodeHtmlEntities = (text: string): string => {

--- a/src/pages/SnsPage.tsx
+++ b/src/pages/SnsPage.tsx
@@ -24,6 +24,7 @@ import {
 const SNS_PAGE_CACHE_TTL_MS = 24 * 60 * 60 * 1000
 const SNS_PAGE_CACHE_POST_LIMIT = 200
 const SNS_PAGE_CACHE_SCOPE_FALLBACK = '__default__'
+const SNS_PAGE_CACHE_SCHEMA_VERSION = 'v2'
 const CONTACT_COUNT_SORT_DEBOUNCE_MS = 200
 const CONTACT_COUNT_BATCH_SIZE = 10
 
@@ -528,7 +529,7 @@ export default function SnsPage() {
     const ensureSnsCacheScopeKey = useCallback(async () => {
         if (cacheScopeKeyRef.current) return cacheScopeKeyRef.current
         const wxid = (await configService.getMyWxid())?.trim() || SNS_PAGE_CACHE_SCOPE_FALLBACK
-        const scopeKey = `sns_page:${wxid}`
+        const scopeKey = `sns_page:${SNS_PAGE_CACHE_SCHEMA_VERSION}:${wxid}`
         cacheScopeKeyRef.current = scopeKey
         return scopeKey
     }, [])


### PR DESCRIPTION
我是很早之前安装的weflow和微信，在某一次升级之后，所有新的朋友圈都无法正常显示了，旧朋友圈显示正常，最新版本main复现情况如下
<img width="1513" height="530" alt="图片" src="https://github.com/user-attachments/assets/d9466054-37d0-480e-9e1d-d5b789eb07fd" />
修复后，本机测试新旧朋友圈均显示正常
本 PR 修复朋友圈媒体在不同 XML / 缓存数据格式下的加载兼容性问题，重点解决缩略图与原图使用不同 `key` / `token` 时图片无法正常显示的问题。
主要变更包括：
- 保留朋友圈 XML 中原图与缩略图各自独立的 `key`、`token`、`enc_idx`
- 为图片加载增加多候选 fallback 策略，兼容新旧朋友圈媒体格式
- 扩展视频 URL 识别逻辑，支持 `stodownload` 类型的视频资源
- 升级 SNS 页面缓存 schema，避免旧缓存数据结构影响新字段解析
## Details
### 1. 保留缩略图专用媒体字段
此前解析 SNS XML 时，会将 `url` 和 `thumb` 上的 `token` / `key` 混合回退到同一组字段中：
- `token`
- `key`
- `encIdx`
这会导致一个问题：当朋友圈媒体的原图和缩略图分别使用不同的加密参数时，缩略图可能会错误地使用原图的 key，或原图错误地使用缩略图的 key，从而导致解密失败、图片无法显示。
本 PR 在 `SnsMedia` 和 `SnsLivePhoto` 中新增并保留缩略图专用字段：
- `thumbToken`
- `thumbKey`
- `thumbEncIdx`
同时保留原始媒体字段：
- `token`
- `key`
- `encIdx`
这样前端在加载缩略图时可以优先使用缩略图自己的解密信息，在需要加载原图或视频时仍然使用主媒体字段。
### 2. 修复 XML 媒体解析逻辑
`electron/services/snsService.ts` 中的媒体解析逻辑现在会分别解析：
- `<url>` 标签上的 `token` / `key` / `enc_idx`
- `<thumb>` 标签上的 `token` / `key` / `enc_idx`
- `livePhoto` 内部的主视频与缩略图字段
对于 Live Photo，也同步保留：
- 主资源的 `token` / `key` / `encIdx`
- 缩略图资源的 `thumbToken` / `thumbKey` / `thumbEncIdx`
避免 Live Photo 缩略图或视频资源因为 key 混用而加载失败。
### 3. 合并数据库媒体数据与 XML 媒体数据
在 `getTimeline` 中，PR 增加了从 `rawXml` 中重新解析媒体信息，并通过 URL / thumb URL / 下标匹配的方式，将 XML 中更完整的媒体字段补充到数据库返回的数据里。
合并后的字段包括：
- `url`
- `thumb`
- `token`
- `thumbToken`
- `key`
- `thumbKey`
- `encIdx`
- `thumbEncIdx`
- `livePhoto`
这可以兼容以下情况：
- 数据库媒体数据缺少缩略图 key
- XML 中包含更完整的媒体加密信息
- 旧版 DLL / 缓存数据只返回了部分媒体字段
- 视频朋友圈需要额外使用 `videoKey`
### 4. 图片加载增加多候选 fallback
`SnsMediaGrid` 中图片加载逻辑从单次请求改为多候选尝试。
对于非视频媒体，现在会依次尝试：
1. 当前目标 URL + 对应的缩略图 key 或主 key
2. 当前目标 URL + 主 key
3. 原图 URL + 主 key
4. 原图 URL + 缩略图 key
并去重后逐个调用 `sns.proxyImage`，直到成功为止。
这样可以兼容：
- 新格式：缩略图需要使用 `thumbKey`
- 旧格式：缩略图仍然使用主 `key`
- 缓存数据中只有主图 URL 或只有缩略图 URL
- 部分历史数据中 key 与 URL 对应关系不一致
如果所有候选都失败，非视频媒体会 fallback 到原始 URL，避免直接进入删除状态导致图片完全不可见。
### 5. 视频 URL 识别兼容 `stodownload`
本 PR 在多个位置扩展了朋友圈视频 URL 判断逻辑，新增对 `stodownload` 的识别：
- `electron/services/snsService.ts`
- `src/components/Sns/SnsMediaGrid.tsx`
- `src/components/Sns/SnsPostItem.tsx`
原先只识别：
- `snsvideodownload`
- `.mp4`
- `video`
现在额外识别：
- `stodownload`
同时仍然排除 `vweixinthumb` 缩略图域名，避免误判缩略图为视频。
### 6. SNS 页面缓存 schema 升级
`src/pages/SnsPage.tsx` 中新增：
```ts
const SNS_PAGE_CACHE_SCHEMA_VERSION = 'v2'
```