### PR TITLE
Security: Sensitive Configuration Passed to Worker Threads Without Encryption

### DIFF
--- a/electron/annualReportWorker.ts
+++ b/electron/annualReportWorker.ts
@@ -4,15 +4,20 @@ import { annualReportService } from './services/annualReportService'
 
 interface WorkerConfig {
   year: number
-  dbPath: string
-  decryptKey: string
-  myWxid: string
   resourcesPath?: string
   userDataPath?: string
   logEnabled?: boolean
 }
 
+interface SensitiveConfig {
+  dbPath: string
+  decryptKey: string
+  myWxid: string
+}
+
 const config = workerData as WorkerConfig
+let sensitiveConfig: SensitiveConfig | null = null
+
 process.env.WEFLOW_WORKER = '1'
 if (config.resourcesPath) {
   process.env.WCDB_RESOURCES_PATH = config.resourcesPath
@@ -21,12 +26,23 @@ if (config.resourcesPath) {
 wcdbService.setPaths(config.resourcesPath || '', config.userDataPath || '')
 wcdbService.setLogEnabled(config.logEnabled === true)
 
+parentPort?.on('message', (message: { type: string; data?: SensitiveConfig }) => {
+  if (message.type === 'annualReport:config' && message.data) {
+    sensitiveConfig = message.data
+  }
+})
+
 async function run() {
+  if (!sensitiveConfig) {
+    parentPort?.postMessage({ type: 'annualReport:error', error: 'Missing sensitive config' })
+    return
+  }
+
   const result = await annualReportService.generateReportWithConfig({
     year: config.year,
-    dbPath: config.dbPath,
-    decryptKey: config.decryptKey,
-    wxid: config.myWxid,
+    dbPath: sensitiveConfig.dbPath,
+    decryptKey: sensitiveConfig.decryptKey,
+    wxid: sensitiveConfig.myWxid,
     onProgress: (status: string, progress: number) => {
       parentPort?.postMessage({
         type: 'annualReport:progress',


### PR DESCRIPTION
## Problem

The worker files `electron/annualReportWorker.ts` and `electron/dualReportWorker.ts` receive sensitive configuration via `workerData` including `dbPath`, `decryptKey`, and `myWxid`. This data is passed in plaintext and could be exposed through process inspection or crash dumps.

**Severity**: `high`
**File**: `electron/annualReportWorker.ts`

## Solution

Avoid passing sensitive data like decryption keys directly to worker threads. Instead, use secure IPC mechanisms or store sensitive data in encrypted form that workers can retrieve through secure channels.

## Changes

- `electron/annualReportWorker.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
