### PR TITLE
fix: 无可用账号时可进入账号管理界面；删除配置后持久化隐藏已删除账号

### DIFF
--- a/src/components/RouteGuard.tsx
+++ b/src/components/RouteGuard.tsx
@@ -6,7 +6,7 @@ interface RouteGuardProps {
   children: React.ReactNode
 }
 
-const PUBLIC_ROUTES = ['/', '/home', '/settings']
+const PUBLIC_ROUTES = ['/', '/home', '/settings', '/account-management']
 
 function RouteGuard({ children }: RouteGuardProps) {
   const navigate = useNavigate()

--- a/src/pages/AccountManagementPage.tsx
+++ b/src/pages/AccountManagementPage.tsx
@@ -46,7 +46,43 @@ type NoticeState =
 
 const SIDEBAR_USER_PROFILE_CACHE_KEY = 'sidebar_user_profile_cache_v1'
 const ACCOUNT_PROFILES_CACHE_KEY = 'account_profiles_cache_v1'
-const hiddenDeletedAccountIds = new Set<string>()
+
+const HIDDEN_DELETED_ACCOUNT_NORM_IDS_KEY = 'weflow_account_mgmt_hidden_deleted_norm_v1'
+
+const readHiddenDeletedAccountNormIds = (): Set<string> => {
+  try {
+    const raw = window.localStorage.getItem(HIDDEN_DELETED_ACCOUNT_NORM_IDS_KEY)
+    if (!raw) return new Set()
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return new Set()
+    return new Set(parsed.filter((x): x is string => typeof x === 'string' && x.length > 0))
+  } catch {
+    return new Set()
+  }
+}
+
+const writeHiddenDeletedAccountNormIds = (ids: Set<string>): void => {
+  try {
+    window.localStorage.setItem(HIDDEN_DELETED_ACCOUNT_NORM_IDS_KEY, JSON.stringify(Array.from(ids)))
+  } catch {
+    // 存储配额或隐私模式
+  }
+}
+
+const addHiddenDeletedAccountNormId = (normalized: string): void => {
+  if (!normalized) return
+  const next = readHiddenDeletedAccountNormIds()
+  next.add(normalized)
+  writeHiddenDeletedAccountNormIds(next)
+}
+
+const removeHiddenDeletedAccountNormId = (normalized: string): void => {
+  if (!normalized) return
+  const next = readHiddenDeletedAccountNormIds()
+  if (!next.delete(normalized)) return
+  writeHiddenDeletedAccountNormIds(next)
+}
+
 const DEFAULT_ACCOUNT_DISPLAY_NAME = '微信用户'
 
 const normalizeAccountId = (value?: string | null): string => {
@@ -194,12 +230,14 @@ function AccountManagementPage() {
         })
       }
 
-      // 被“删除配置”操作移除的账号，在当前会话中从列表隐藏；
-      // 若后续再次生成配置，则自动恢复展示。
+      // 被「删除配置」移除的账号：微信目录仍在扫描结果里会出现无配置条目，持久化隐藏避免误导；
+      // 若后续再次保存该账号配置，则自动恢复展示。
+      const hiddenDeletedNormIds = readHiddenDeletedAccountNormIds()
       for (const [normalized, item] of Array.from(merged.entries())) {
-        if (!hiddenDeletedAccountIds.has(normalized)) continue
+        if (!hiddenDeletedNormIds.has(normalized)) continue
         if (item.hasConfig) {
-          hiddenDeletedAccountIds.delete(normalized)
+          hiddenDeletedNormIds.delete(normalized)
+          writeHiddenDeletedAccountNormIds(hiddenDeletedNormIds)
           continue
         }
         merged.delete(normalized)
@@ -362,7 +400,7 @@ function AccountManagementPage() {
           const [nextWxid, nextConfig] = remainingEntries[0]
           await applyWxidConfig(nextWxid, nextConfig || null)
           window.dispatchEvent(new CustomEvent('wxid-changed', { detail: { wxid: nextWxid } }))
-          hiddenDeletedAccountIds.add(normalizedTarget)
+          addHiddenDeletedAccountNormId(normalizedTarget)
           setDeleteUndoState(undoPayload)
           setNotice({ type: 'success', text: `已删除「${targetWxid}」配置，并切换到「${nextWxid}」` })
           await loadAccounts()
@@ -375,14 +413,14 @@ function AccountManagementPage() {
         await configService.setImageAesKey('')
         setDbConnected(false)
         window.dispatchEvent(new CustomEvent('wxid-changed', { detail: { wxid: '' } }))
-        hiddenDeletedAccountIds.add(normalizedTarget)
+        addHiddenDeletedAccountNormId(normalizedTarget)
         setDeleteUndoState(undoPayload)
         setNotice({ type: 'info', text: `已删除「${targetWxid}」配置，当前无可用账号配置，可撤回或添加账号` })
         await loadAccounts()
         return
       }
 
-      hiddenDeletedAccountIds.add(normalizedTarget)
+      addHiddenDeletedAccountNormId(normalizedTarget)
       setDeleteUndoState(undoPayload)
       setNotice({ type: 'success', text: `已删除账号「${targetWxid}」配置` })
       await loadAccounts()
@@ -406,7 +444,7 @@ function AccountManagementPage() {
         restoredConfigs[key] = configValue || {}
       }
       await configService.setWxidConfigs(restoredConfigs)
-      hiddenDeletedAccountIds.delete(normalizeAccountId(deleteUndoState.targetWxid) || deleteUndoState.targetWxid)
+      removeHiddenDeletedAccountNormId(normalizeAccountId(deleteUndoState.targetWxid) || deleteUndoState.targetWxid)
 
       const accountProfileCache = readAccountProfilesCache()
       for (const [key, profile] of deleteUndoState.deletedProfileEntries) {

--- a/src/pages/AccountManagementPage.tsx
+++ b/src/pages/AccountManagementPage.tsx
@@ -65,7 +65,7 @@ const writeHiddenDeletedAccountNormIds = (ids: Set<string>): void => {
   try {
     window.localStorage.setItem(HIDDEN_DELETED_ACCOUNT_NORM_IDS_KEY, JSON.stringify(Array.from(ids)))
   } catch {
-    // 存储配额或隐私模式
+    
   }
 }
 


### PR DESCRIPTION
Related: #956 
### 主要改动

1.` src/components/RouteGuard.tsx `中将 `/account-management` 加入公开路由，在未连库时仍可进入账号管理，以便通过「添加账号」完成引导。
3. `src/pages/AccountManagementPage.tsx` 中将「已删除本地配置」的账号按 normalize 后的 id 写入 `localStorage`（`weflow_account_mgmt_hidden_deleted_norm_v1`），加载列表时过滤无配置的幽灵条目；当该账号再次存在已保存配置时，从隐藏集合移除并恢复展示。撤回删除时同步从该集合移除。

### 测试

- 删除全部账号配置后重启应用：侧栏进入账号管理应正常，「添加账号」可打开引导窗。
- 删除单账号配置后离开再进入或重启：不应再出现仅扫描、无配置且无法删除的卡片。
- 删除后点「撤回」：账号应重新出现在列表且可再次管理。
- 通过「添加账号」等为同一 wxid 重新保存配置后：该账号应重新出现在列表中。