### PR TITLE
fix(api): refresh image export cache when larger file is available

### DIFF
--- a/electron/services/httpService.ts
+++ b/electron/services/httpService.ts
@@ -1417,6 +1417,20 @@ class HttpService {
     return '.jpg'
   }
 
+  private writeFileIfLarger(fullPath: string, data: Buffer): void {
+    if (fs.existsSync(fullPath)) {
+      try {
+        const stat = fs.statSync(fullPath)
+        if (!stat.isFile()) return
+        if (data.length <= stat.size) return
+      } catch {
+        // If the existing export cannot be inspected, overwrite it below.
+      }
+    }
+
+    fs.writeFileSync(fullPath, data)
+  }
+
   private async exportMediaForMessages(
     messages: Message[],
     talker: string,
@@ -1516,9 +1530,7 @@ class HttpService {
             const targetDir = path.join(sessionDir, 'images')
             const fullPath = path.join(targetDir, fileName)
             this.ensureDir(targetDir)
-            if (!fs.existsSync(fullPath)) {
-              fs.writeFileSync(fullPath, imageBuffer)
-            }
+            this.writeFileIfLarger(fullPath, imageBuffer)
             const relativePath = `${this.sanitizeFileName(talker, 'session')}/images/${fileName}`
             return { kind: 'image', fileName, fullPath, relativePath }
           }
@@ -1531,9 +1543,7 @@ class HttpService {
             const targetDir = path.join(sessionDir, 'images')
             const fullPath = path.join(targetDir, fileName)
             this.ensureDir(targetDir)
-            if (!fs.existsSync(fullPath)) {
-              fs.copyFileSync(imagePath, fullPath)
-            }
+            this.writeFileIfLarger(fullPath, imageBuffer)
             const relativePath = `${this.sanitizeFileName(talker, 'session')}/images/${fileName}`
             return { kind: 'image', fileName, fullPath, relativePath }
           }


### PR DESCRIPTION
Fixes hicccc77/WeFlow#949

### What changed
Update HTTP API image export cache logic so a later larger image can overwrite an existing smaller cached image.

### Why
Previously, if the file already existed, WeFlow skipped writing it, so an exported thumbnail could keep blocking the later high-resolution image.

### Testing
- Ran `git diff --check`