### PR TITLE
fix(linux): initialize key service in packaged builds

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -397,13 +397,7 @@ let keyService: any
 if (process.platform === 'darwin') {
   keyService = new KeyServiceMac()
 } else if (process.platform === 'linux') {
-  // const { KeyServiceLinux } = require('./services/keyServiceLinux')
-  // keyService = new KeyServiceLinux()
-
-  import('./services/keyServiceLinux').then(({ KeyServiceLinux }) => {
-    keyService = new KeyServiceLinux();
-  });
-
+  keyService = new KeyServiceLinux()
 } else {
   keyService = new KeyService()
 }

--- a/electron/services/keyServiceLinux.ts
+++ b/electron/services/keyServiceLinux.ts
@@ -5,7 +5,7 @@ import { execFile, exec, spawn } from 'child_process'
 import { promisify } from 'util'
 import crypto from 'crypto'
 import { createRequire } from 'module';
-const require = createRequire(import.meta.url);
+const require = createRequire(__filename);
 
 const execFileAsync = promisify(execFile)
 const execAsync = promisify(exec)


### PR DESCRIPTION
### 变更内容

修复 Linux 打包版中自动获取密钥相关 IPC handler 报 `keyService` 为 `undefined` 的问题。

本 PR 只包含两个最小改动：

- Linux 分支直接同步初始化 `KeyServiceLinux`
- `keyServiceLinux.ts` 使用 `createRequire(__filename)`，避免打包后的 CommonJS 产物中 `createRequire(import.meta.url)` 得到无效参数

Fixes #976

### 问题原因

`main.ts` 已经静态导入了 `KeyServiceLinux`，但 Linux 分支又通过异步 `import(...).then(...)` 给 `keyService` 赋值：

```ts
import('./services/keyServiceLinux').then(({ KeyServiceLinux }) => {
  keyService = new KeyServiceLinux();
});
```

IPC handler 注册后，用户点击自动获取密钥时，`keyService` 可能还没赋值，导致：

```text
Cannot read properties of undefined (reading 'autoGetDbKey')
Cannot read properties of undefined (reading 'autoGetImageKey')
```

同时，打包后的 Linux key service 中 `createRequire(import.meta.url)` 可能被转换成无效参数，导致模块加载失败：

```text
TypeError [ERR_INVALID_ARG_VALUE]: Received undefined
```

### 修复方式

```ts
keyService = new KeyServiceLinux()
```

以及：

```ts
const require = createRequire(__filename);
```

### 验证

- `npm run typecheck` 通过
- `npm run build` 通过
- 在 `upstream/main` 构建并安装后可复现 `keyService undefined`
- 切换到本修复分支重新构建并安装后，初始化流程和图片解密验证通过

### 备注

本 PR 不处理 `APPIMAGE env is not defined, current application is not an AppImage`。该日志是非 AppImage 安装方式下 electron-updater 的提示，不是本次 Linux key service 崩溃的根因。
