### PR TITLE
fix: 修复朋友圈图片显示"已删除"和数据库备份卡住的两个 Bug

### DIFF
--- a/electron/services/backupService.ts
+++ b/electron/services/backupService.ts
@@ -467,10 +467,10 @@ export class BackupService {
     )
     if (!opened) {
       const detail = await wcdbService.getLastInitError().catch(() => null)
-      return { success: false, error: detail || `目标账号 ${accountDirName} 数据库连接失败` }
+      return { success: false, error: detail || `目标账号 ${accountDir} 数据库连接失败` }
     }
 
-    return { success: true, wxid: accountDirName, dbPath, dbStorage }
+    return { success: true, wxid: accountDir, dbPath, dbStorage }
   }
 
   private buildDbId(kind: BackupDbKind, index: number, dbPath: string): string {
@@ -857,10 +857,13 @@ export class BackupService {
       if (!existsSync(manifestPath)) return { success: false, error: '备份包缺少 manifest.json' }
       const manifest = JSON.parse(await readFileAsync(manifestPath, 'utf8')) as BackupManifest
       if (manifest?.type !== 'weflow-db-snapshots' || manifest.version !== 1) {
+        emitBackupProgress({ phase: 'failed', message: '不支持的备份包格式' })
         return { success: false, error: '不支持的备份包格式' }
       }
+      emitBackupProgress({ phase: 'done', message: '备份包已读取' })
       return { success: true, manifest }
     } catch (e) {
+      emitBackupProgress({ phase: 'failed', message: e instanceof Error ? e.message : String(e) })
       return { success: false, error: e instanceof Error ? e.message : String(e) }
     } finally {
       if (extractDir) {

--- a/electron/services/snsService.ts
+++ b/electron/services/snsService.ts
@@ -126,9 +126,10 @@ const fixSnsUrl = (url: string, token?: string, isVideo: boolean = false) => {
 
     let fixedUrl = url.replace('http://', 'https://')
 
-    // 只有非视频（即图片）才需要处理 /150 变 /0
+    // 只有非视频（即图片）才需要处理缩略图路径变 /0（获取原图）
+    // 支持 /150、/200、/480 等常见的缩略图尺寸
     if (!isVideo) {
-        fixedUrl = fixedUrl.replace(/\/150($|\?)/, '/0$1')
+        fixedUrl = fixedUrl.replace(/\/(150|200|480)($|\?)/, '/0$2')
     }
 
     if (!token || fixedUrl.includes('token=')) return fixedUrl
@@ -2060,6 +2061,8 @@ window.addEventListener('scroll',function(){document.getElementById('btt').class
                 const zlib = require('zlib')
                 const urlObj = new URL(url)
 
+                console.log(`[SnsService] 开始下载图片: url=${url.substring(0, 100)}..., key=${key || 'undefined'}`)
+
                 const options = {
                     hostname: urlObj.hostname,
                     path: urlObj.pathname + urlObj.search,
@@ -2074,7 +2077,9 @@ window.addEventListener('scroll',function(){document.getElementById('btt').class
                 }
 
                 const req = https.request(options, (res: any) => {
+                    console.log(`[SnsService] CDN 响应: statusCode=${res.statusCode}, x-enc=${res.headers['x-enc']}, content-type=${res.headers['content-type']}`)
                     if (res.statusCode !== 200 && res.statusCode !== 206) {
+                        console.error(`[SnsService] CDN 请求失败: HTTP ${res.statusCode}`)
                         resolve({ success: false, error: `HTTP ${res.statusCode}` })
                         return
                     }
@@ -2094,9 +2099,11 @@ window.addEventListener('scroll',function(){document.getElementById('btt').class
 
                         let decoded = raw
                         const rawMagicMime = detectImageMime(raw, '')
+                        console.log(`[SnsService] 原始数据: size=${raw.length}, mime=${rawMagicMime}, xEnc=${xEnc}`)
 
                         // 图片逻辑
                         const shouldDecrypt = (xEnc === '1' || !!key) && key !== undefined && key !== null && String(key).trim().length > 0
+                        console.log(`[SnsService] 解密判断: shouldDecrypt=${shouldDecrypt}, key=${key || 'undefined'}`)
                         if (shouldDecrypt) {
                             try {
                                 const keyStr = String(key).trim()
@@ -2112,6 +2119,7 @@ window.addEventListener('scroll',function(){document.getElementById('btt').class
                                     }
 
                                     const decryptedMagicMime = detectImageMime(decrypted, '')
+                                    console.log(`[SnsService] 解密后: mime=${decryptedMagicMime}`)
                                     if (decryptedMagicMime.startsWith('image/')) {
                                         decoded = decrypted
                                     } else if (!rawMagicMime.startsWith('image/')) {
@@ -2124,7 +2132,9 @@ window.addEventListener('scroll',function(){document.getElementById('btt').class
                         }
 
                         const decodedMagicMime = detectImageMime(decoded, '')
+                        console.log(`[SnsService] 最终结果: mime=${decodedMagicMime}, isImage=${decodedMagicMime.startsWith('image/')}`)
                         if (!decodedMagicMime.startsWith('image/')) {
+                            console.error(`[SnsService] 图片解密失败: 原始mime=${rawMagicMime}, 解密后mime=${decodedMagicMime}, key=${key}`)
                             resolve({ success: false, error: '图片解密失败：无法识别图片格式' })
                             return
                         }


### PR DESCRIPTION
1. snsService.ts: fixSnsUrl 正则只处理 /150 缩略图路径， 实际 CDN 返回 /200 导致 HTTP 400，改为支持 /150|200|480

2. backupService.ts: inspectBackup 缺少完成事件导致界面卡死， ensureConnected 中 accountDirName 变量名未定义