### PR TITLE
fix: prevent export worker shutdown crashes

### DIFF
--- a/electron/annualReportWorker.ts
+++ b/electron/annualReportWorker.ts
@@ -21,23 +21,31 @@ if (config.resourcesPath) {
 wcdbService.setPaths(config.resourcesPath || '', config.userDataPath || '')
 wcdbService.setLogEnabled(config.logEnabled === true)
 
-async function run() {
-  const result = await annualReportService.generateReportWithConfig({
-    year: config.year,
-    dbPath: config.dbPath,
-    decryptKey: config.decryptKey,
-    wxid: config.myWxid,
-    onProgress: (status: string, progress: number) => {
-      parentPort?.postMessage({
-        type: 'annualReport:progress',
-        data: { status, progress }
-      })
-    }
-  })
-
-  parentPort?.postMessage({ type: 'annualReport:result', data: result })
+async function shutdownWorkerServices(): Promise<void> {
+  try { await wcdbService.shutdown() } catch {}
 }
 
-run().catch((err) => {
-  parentPort?.postMessage({ type: 'annualReport:error', error: String(err) })
-})
+async function run() {
+  try {
+    const result = await annualReportService.generateReportWithConfig({
+      year: config.year,
+      dbPath: config.dbPath,
+      decryptKey: config.decryptKey,
+      wxid: config.myWxid,
+      onProgress: (status: string, progress: number) => {
+        parentPort?.postMessage({
+          type: 'annualReport:progress',
+          data: { status, progress }
+        })
+      }
+    })
+
+    await shutdownWorkerServices()
+    parentPort?.postMessage({ type: 'annualReport:result', data: result })
+  } catch (err) {
+    await shutdownWorkerServices()
+    parentPort?.postMessage({ type: 'annualReport:error', error: String(err) })
+  }
+}
+
+void run()

--- a/electron/dualReportWorker.ts
+++ b/electron/dualReportWorker.ts
@@ -23,25 +23,33 @@ if (config.resourcesPath) {
 wcdbService.setPaths(config.resourcesPath || '', config.userDataPath || '')
 wcdbService.setLogEnabled(config.logEnabled === true)
 
-async function run() {
-  const result = await dualReportService.generateReportWithConfig({
-    year: config.year,
-    friendUsername: config.friendUsername,
-    dbPath: config.dbPath,
-    decryptKey: config.decryptKey,
-    wxid: config.myWxid,
-    excludeWords: config.excludeWords,
-    onProgress: (status: string, progress: number) => {
-      parentPort?.postMessage({
-        type: 'dualReport:progress',
-        data: { status, progress }
-      })
-    }
-  })
-
-  parentPort?.postMessage({ type: 'dualReport:result', data: result })
+async function shutdownWorkerServices(): Promise<void> {
+  try { await wcdbService.shutdown() } catch {}
 }
 
-run().catch((err) => {
-  parentPort?.postMessage({ type: 'dualReport:error', error: String(err) })
-})
+async function run() {
+  try {
+    const result = await dualReportService.generateReportWithConfig({
+      year: config.year,
+      friendUsername: config.friendUsername,
+      dbPath: config.dbPath,
+      decryptKey: config.decryptKey,
+      wxid: config.myWxid,
+      excludeWords: config.excludeWords,
+      onProgress: (status: string, progress: number) => {
+        parentPort?.postMessage({
+          type: 'dualReport:progress',
+          data: { status, progress }
+        })
+      }
+    })
+
+    await shutdownWorkerServices()
+    parentPort?.postMessage({ type: 'dualReport:result', data: result })
+  } catch (err) {
+    await shutdownWorkerServices()
+    parentPort?.postMessage({ type: 'dualReport:error', error: String(err) })
+  }
+}
+
+void run()

--- a/electron/exportWorker.ts
+++ b/electron/exportWorker.ts
@@ -137,80 +137,92 @@ if (config.userDataPath) {
 }
 process.env.WEFLOW_PROJECT_NAME = process.env.WEFLOW_PROJECT_NAME || 'WeFlow'
 
-async function run() {
-  const [{ wcdbService }, { exportService }] = await Promise.all([
-    import('./services/wcdbService'),
-    import('./services/exportService')
-  ])
-
-  wcdbService.setPaths(config.resourcesPath || '', config.userDataPath || '')
-  wcdbService.setLogEnabled(config.logEnabled === true)
-  exportService.setRuntimeConfig({
-    dbPath: config.dbPath,
-    decryptKey: config.decryptKey,
-    myWxid: config.myWxid,
-    imageXorKey: config.imageXorKey,
-    imageAesKey: config.imageAesKey
-  })
-
-  const onProgress = (progress: any) => queueProgress(progress)
-
-  const taskControl = config.taskId
-    ? {
-        shouldPause: () => controlState.pauseRequested,
-        shouldStop: () => controlState.stopRequested,
-        recordCreatedFile: queueCreatedFile,
-        recordCreatedDir: queueCreatedDir
-      }
-    : undefined
-
-  let result: any
-  if (config.mode === 'contacts') {
-    const [{ contactExportService }, { chatService }] = await Promise.all([
-      import('./services/contactExportService'),
-      import('./services/chatService')
-    ])
-    chatService.setRuntimeConfig({
-      dbPath: config.dbPath,
-      decryptKey: config.decryptKey,
-      myWxid: config.myWxid
-    })
-    result = await contactExportService.exportContacts(
-      String(config.outputDir || ''),
-      config.options || {}
-    )
-  } else if (config.mode === 'single') {
-    result = await exportService.exportSessionToChatLab(
-      String(config.sessionId || '').trim(),
-      String(config.outputPath || '').trim(),
-      config.options || { format: 'chatlab' },
-      onProgress,
-      taskControl
-    )
-  } else {
-    result = await exportService.exportSessions(
-      Array.isArray(config.sessionIds) ? config.sessionIds : [],
-      String(config.outputDir || ''),
-      config.options || { format: 'json' },
-      onProgress,
-      taskControl
-    )
-  }
-
-  flushProgress()
-  flushCreatedPaths()
-
-  parentPort?.postMessage({
-    type: 'export:result',
-    data: result
-  })
+async function shutdownWcdbService(service: { shutdown: () => Promise<void> } | null): Promise<void> {
+  if (!service) return
+  try { await service.shutdown() } catch {}
 }
 
-run().catch((error) => {
-  flushProgress()
-  flushCreatedPaths()
-  parentPort?.postMessage({
-    type: 'export:error',
-    error: String(error)
-  })
-})
+async function run() {
+  let wcdbServiceRef: { shutdown: () => Promise<void> } | null = null
+
+  try {
+    const [{ wcdbService }, { exportService }] = await Promise.all([
+      import('./services/wcdbService'),
+      import('./services/exportService')
+    ])
+
+    wcdbServiceRef = wcdbService
+    wcdbService.setPaths(config.resourcesPath || '', config.userDataPath || '')
+    wcdbService.setLogEnabled(config.logEnabled === true)
+    exportService.setRuntimeConfig({
+      dbPath: config.dbPath,
+      decryptKey: config.decryptKey,
+      myWxid: config.myWxid,
+      imageXorKey: config.imageXorKey,
+      imageAesKey: config.imageAesKey
+    })
+
+    const onProgress = (progress: any) => queueProgress(progress)
+
+    const taskControl = config.taskId
+      ? {
+          shouldPause: () => controlState.pauseRequested,
+          shouldStop: () => controlState.stopRequested,
+          recordCreatedFile: queueCreatedFile,
+          recordCreatedDir: queueCreatedDir
+        }
+      : undefined
+
+    let result: any
+    if (config.mode === 'contacts') {
+      const [{ contactExportService }, { chatService }] = await Promise.all([
+        import('./services/contactExportService'),
+        import('./services/chatService')
+      ])
+      chatService.setRuntimeConfig({
+        dbPath: config.dbPath,
+        decryptKey: config.decryptKey,
+        myWxid: config.myWxid
+      })
+      result = await contactExportService.exportContacts(
+        String(config.outputDir || ''),
+        config.options || {}
+      )
+    } else if (config.mode === 'single') {
+      result = await exportService.exportSessionToChatLab(
+        String(config.sessionId || '').trim(),
+        String(config.outputPath || '').trim(),
+        config.options || { format: 'chatlab' },
+        onProgress,
+        taskControl
+      )
+    } else {
+      result = await exportService.exportSessions(
+        Array.isArray(config.sessionIds) ? config.sessionIds : [],
+        String(config.outputDir || ''),
+        config.options || { format: 'json' },
+        onProgress,
+        taskControl
+      )
+    }
+
+    flushProgress()
+    flushCreatedPaths()
+    await shutdownWcdbService(wcdbServiceRef)
+
+    parentPort?.postMessage({
+      type: 'export:result',
+      data: result
+    })
+  } catch (error) {
+    flushProgress()
+    flushCreatedPaths()
+    await shutdownWcdbService(wcdbServiceRef)
+    parentPort?.postMessage({
+      type: 'export:error',
+      error: String(error)
+    })
+  }
+}
+
+void run()

--- a/electron/services/wcdbService.ts
+++ b/electron/services/wcdbService.ts
@@ -24,6 +24,7 @@ export class WcdbService {
   private userDataPath: string | null = null
   private logEnabled = false
   private monitorListener: ((type: string, json: string) => void) | null = null
+  private shuttingDown = false
 
   constructor() {}
 
@@ -75,16 +76,20 @@ export class WcdbService {
       })
 
       this.worker.on('exit', (code) => {
-        // Worker 退出，需要 reject 所有 pending promises
-        if (code !== 0) {
-          console.error('WCDB Worker 异常退出，退出码:', code)
-          const errorMsg = `Worker 异常退出 (退出码: ${code})。可能是数据服务加载失败，请检查是否安装了 Visual C++ Redistributable。`
-          for (const [id, p] of this.pending) {
+        if (this.pending.size > 0) {
+          const errorMsg = code === 0
+            ? 'Worker 已退出'
+            : `Worker 异常退出 (退出码: ${code})。可能是数据服务加载失败，请检查是否安装了 Visual C++ Redistributable。`
+          if (code !== 0 && !this.shuttingDown) {
+            console.error('WCDB Worker 异常退出，退出码:', code)
+          }
+          for (const [, p] of this.pending) {
             p.reject(new Error(errorMsg))
           }
           this.pending.clear()
         }
         this.worker = null
+        this.shuttingDown = false
       })
 
       // 如果已有路径配置，重新发送给新的 worker
@@ -182,11 +187,14 @@ export class WcdbService {
    * 关闭服务
    */
   async shutdown(): Promise<void> {
+    if (!this.worker) return
+    this.shuttingDown = true
     try { await this.close() } catch {}
     if (this.worker) {
       try { await this.worker.terminate() } catch {}
       this.worker = null
     }
+    this.shuttingDown = false
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "remark-gfm": "^4.0.1",
         "sherpa-onnx-node": "^1.10.38",
         "silk-wasm": "^3.7.1",
+        "tar": "^7.5.13",
         "wechat-emojis": "^1.0.2",
         "zustand": "^5.0.2"
       },
@@ -1666,7 +1667,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.4"
@@ -3590,7 +3590,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -7492,7 +7491,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -7632,7 +7630,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
       "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.1.2"
@@ -9225,7 +9222,6 @@
       "version": "7.5.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
       "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -9258,7 +9254,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "remark-gfm": "^4.0.1",
     "sherpa-onnx-node": "^1.10.38",
     "silk-wasm": "^3.7.1",
+    "tar": "^7.5.13",
     "wechat-emojis": "^1.0.2",
     "zustand": "^5.0.2"
   },


### PR DESCRIPTION
## Summary
- Shut down the nested WCDB worker before export, annual report, and dual report workers post final result/error messages.
- Suppress false abnormal-exit handling during intentional WCDB shutdown while still rejecting pending calls if the worker exits mid-shutdown.
- Declare `tar` as a runtime dependency because `electron/services/backupService.ts` imports it from the main process.

## Observed crash
This addresses a real macOS crash seen when WeFlow 4.5.1 finished an export. The crash report showed:

- `Exception Type: EXC_CRASH (SIGABRT)` / `abort() called`
- Triggered thread: `WorkerThread`
- Main thread was joining a Node worker during teardown:
  - `uv_thread_join`
  - `node::worker::Worker::JoinThread()`
  - `node::Environment::stop_sub_worker_contexts()`
  - `node::FreeEnvironment(...)`
- The triggered worker aborted from a native addon path:
  - `node::OnFatalError(...)`
  - `napi_fatal_error`
  - `Napi::Error::ThrowAsJavaScriptException()`
  - `K::DecodeNormalArray(...)` / `K::CallData::PopOutArguments()`
  - loaded from `app.asar.unpacked/node_modules/koffi/build/koffi/darwin_arm64/koffi.node`
- The process also had WCDB native libraries loaded from `Resources/resources/wcdb/macos/universal/`.

The export/report workers create a nested WCDB service worker. Returning the final worker result before explicitly closing that nested worker can leave WCDB/koffi native resources alive while Node is tearing the outer worker down, matching the crash stack above.

## Verification
- `npm run typecheck`
- `npm exec vite build`
- `npm exec electron-builder -- --mac dir --arm64`
- `codesign --verify --deep --strict --verbose=2 release/mac-arm64/WeFlow.app`
- Confirmed packaged `app.asar` contains `/node_modules/pako/package.json` and `/node_modules/tar/package.json`

## Notes
The repo README documents `npm install` for source builds, and this PR follows the committed `package-lock.json` workflow.