### PR TITLE
fix(export): 修复导出页文件消息数量始终显示为 0

### DIFF
--- a/electron/services/chatService.ts
+++ b/electron/services/chatService.ts
@@ -4600,6 +4600,14 @@ class ChatService {
           const localType = this.getRowInt(row, ['local_type'], 1)
           if (!fileLocalTypeSet.has(localType)) continue
 
+          // 文件消息变体中，49 是通用 appmsg，需要解析 XML 判断 type === 6；
+          // 34359738417 / 103079215153 / 25769803825 等变体几乎专用于文件，直接计数即可，
+          // 避免大量 CPU 密集型 XML 解码/正则解析。
+          if (localType !== 49) {
+            count += 1
+            continue
+          }
+
           const rawMessageContent = row.message_content
           const rawCompressContent = row.compress_content
           const content = this.decodeMessageContent(rawMessageContent, rawCompressContent)
@@ -4664,16 +4672,22 @@ class ChatService {
           if (localType === 50) stats.callMessages += 1
           if (localType === 8589934592049) stats.transferMessages += 1
           if (localType === 8594229559345) stats.redPacketMessages += 1
-          // 文件、转账、红包等共享 appmsg 类型的 localType 变体，需要解析 XML 进一步区分
+          // 文件、转账、红包等共享 appmsg 类型的 localType 变体，需要解析 XML 进一步区分。
+          // 非 49 的文件消息变体（34359738417 / 103079215153 / 25769803825）几乎专用于文件，
+          // 跳过 XML 解析直接计为文件消息，以降低 cursor 扫描开销。
           if (FILE_APP_LOCAL_TYPE_SET.has(localType)) {
-            const rawMessageContent = row.message_content
-            const rawCompressContent = row.compress_content
-            const content = this.decodeMessageContent(rawMessageContent, rawCompressContent)
-            const xmlType = this.extractType49XmlTypeForStats(content)
-            if (xmlType === '2000') stats.transferMessages += 1
-            if (xmlType === '2001') stats.redPacketMessages += 1
-            // appmsg type === 6 表示普通文件附件
-            if (xmlType === '6') stats.fileMessages += 1
+            if (localType !== 49) {
+              stats.fileMessages += 1
+            } else {
+              const rawMessageContent = row.message_content
+              const rawCompressContent = row.compress_content
+              const content = this.decodeMessageContent(rawMessageContent, rawCompressContent)
+              const xmlType = this.extractType49XmlTypeForStats(content)
+              if (xmlType === '2000') stats.transferMessages += 1
+              if (xmlType === '2001') stats.redPacketMessages += 1
+              // appmsg type === 6 表示普通文件附件
+              if (xmlType === '6') stats.fileMessages += 1
+            }
           }
 
           const createTime = this.getRowInt(
@@ -5095,7 +5109,7 @@ class ChatService {
       }
     }
 
-    await this.forEachWithConcurrency(normalizedSessionIds, 3, async (sessionId) => {
+    await this.forEachWithConcurrency(normalizedSessionIds, 6, async (sessionId) => {
       try {
         const fromNativeBatch = hasNativeBatchStats && nativeBatchStats[sessionId]
         const stats = fromNativeBatch

--- a/electron/services/chatService.ts
+++ b/electron/services/chatService.ts
@@ -13,6 +13,7 @@ import { wcdbService } from './wcdbService'
 import { MessageCacheService } from './messageCacheService'
 import { ContactCacheService, ContactCacheEntry } from './contactCacheService'
 import { SessionStatsCacheService, SessionStatsCacheEntry, SessionStatsCacheStats } from './sessionStatsCacheService'
+import { FILE_APP_LOCAL_TYPE_SET } from './export/constants'
 import { GroupMyMessageCountCacheService, GroupMyMessageCountCacheEntry } from './groupMyMessageCountCacheService'
 import { exportCardDiagnosticsService } from './exportCardDiagnosticsService'
 import { voiceTranscribeService } from './voiceTranscribeService'
@@ -181,6 +182,8 @@ interface ExportSessionStats {
   imageMessages: number
   videoMessages: number
   emojiMessages: number
+  /** 文件类消息数量（包含 49 / 34359738417 / 103079215153 / 25769803825 等 localType 变体） */
+  fileMessages: number
   transferMessages: number
   redPacketMessages: number
   callMessages: number
@@ -4233,6 +4236,7 @@ class ChatService {
       imageMessages: Number.isFinite(stats.imageMessages) ? Math.max(0, Math.floor(stats.imageMessages)) : 0,
       videoMessages: Number.isFinite(stats.videoMessages) ? Math.max(0, Math.floor(stats.videoMessages)) : 0,
       emojiMessages: Number.isFinite(stats.emojiMessages) ? Math.max(0, Math.floor(stats.emojiMessages)) : 0,
+      fileMessages: Number.isFinite(stats.fileMessages) ? Math.max(0, Math.floor(stats.fileMessages)) : 0,
       transferMessages: Number.isFinite(stats.transferMessages) ? Math.max(0, Math.floor(stats.transferMessages)) : 0,
       redPacketMessages: Number.isFinite(stats.redPacketMessages) ? Math.max(0, Math.floor(stats.redPacketMessages)) : 0,
       callMessages: Number.isFinite(stats.callMessages) ? Math.max(0, Math.floor(stats.callMessages)) : 0
@@ -4256,6 +4260,7 @@ class ChatService {
       imageMessages: stats.imageMessages,
       videoMessages: stats.videoMessages,
       emojiMessages: stats.emojiMessages,
+      fileMessages: stats.fileMessages,
       transferMessages: stats.transferMessages,
       redPacketMessages: stats.redPacketMessages,
       callMessages: stats.callMessages,
@@ -4511,11 +4516,13 @@ class ChatService {
     transferMessages: number
     redPacketMessages: number
     callMessages: number
+    fileMessages: number
   }> {
     const counters = {
       transferMessages: 0,
       redPacketMessages: 0,
-      callMessages: 0
+      callMessages: 0,
+      fileMessages: 0
     }
 
     const cursorResult = await wcdbService.openMessageCursor(sessionId, 500, false, beginTimestamp, endTimestamp)
@@ -4551,6 +4558,7 @@ class ChatService {
           const xmlType = this.extractType49XmlTypeForStats(content)
           if (xmlType === '2000') counters.transferMessages += 1
           if (xmlType === '2001') counters.redPacketMessages += 1
+          if (xmlType === '6') counters.fileMessages += 1
         }
 
         if (!batch.hasMore || rows.length === 0) break
@@ -4560,6 +4568,52 @@ class ChatService {
     }
 
     return counters
+  }
+
+  /**
+   * 通过 cursor 扫描精确统计指定会话中的文件消息数量。
+   *
+   * 背景：Native 聚合接口 `getSessionMessageTypeStats` 通常只把 localType === 49 且
+   * appmsg type === 6 的消息计为文件；但微信 4.x 中文件消息还存在
+   * 34359738417 / 103079215153 / 25769803825 等 localType 变体，Native 不会计入。
+   * 该函数覆盖 FILE_APP_LOCAL_TYPE_SET 中所有文件变体，作为 Native 统计的兜底/修正。
+   */
+  private async collectFileMessageCountByCursorScan(
+    sessionId: string,
+    beginTimestamp: number = 0,
+    endTimestamp: number = 0
+  ): Promise<number> {
+    let count = 0
+    const fileLocalTypeSet = FILE_APP_LOCAL_TYPE_SET
+    const cursorResult = await wcdbService.openMessageCursor(sessionId, 500, false, beginTimestamp, endTimestamp)
+    if (!cursorResult.success || !cursorResult.cursor) {
+      return count
+    }
+
+    const cursor = cursorResult.cursor
+    try {
+      while (true) {
+        const batch = await wcdbService.fetchMessageBatch(cursor)
+        if (!batch.success) break
+        const rows = Array.isArray(batch.rows) ? batch.rows as Record<string, any>[] : []
+        for (const row of rows) {
+          const localType = this.getRowInt(row, ['local_type'], 1)
+          if (!fileLocalTypeSet.has(localType)) continue
+
+          const rawMessageContent = row.message_content
+          const rawCompressContent = row.compress_content
+          const content = this.decodeMessageContent(rawMessageContent, rawCompressContent)
+          const xmlType = this.extractType49XmlTypeForStats(content)
+          if (xmlType === '6') count += 1
+        }
+
+        if (!batch.hasMore || rows.length === 0) break
+      }
+    } finally {
+      await wcdbService.closeMessageCursor(cursor)
+    }
+
+    return count
   }
 
   private async collectSessionExportStatsByCursorScan(
@@ -4574,6 +4628,7 @@ class ChatService {
       imageMessages: 0,
       videoMessages: 0,
       emojiMessages: 0,
+      fileMessages: 0,
       transferMessages: 0,
       redPacketMessages: 0,
       callMessages: 0
@@ -4609,13 +4664,16 @@ class ChatService {
           if (localType === 50) stats.callMessages += 1
           if (localType === 8589934592049) stats.transferMessages += 1
           if (localType === 8594229559345) stats.redPacketMessages += 1
-          if (localType === 49) {
+          // 文件、转账、红包等共享 appmsg 类型的 localType 变体，需要解析 XML 进一步区分
+          if (FILE_APP_LOCAL_TYPE_SET.has(localType)) {
             const rawMessageContent = row.message_content
             const rawCompressContent = row.compress_content
             const content = this.decodeMessageContent(rawMessageContent, rawCompressContent)
             const xmlType = this.extractType49XmlTypeForStats(content)
             if (xmlType === '2000') stats.transferMessages += 1
             if (xmlType === '2001') stats.redPacketMessages += 1
+            // appmsg type === 6 表示普通文件附件
+            if (xmlType === '6') stats.fileMessages += 1
           }
 
           const createTime = this.getRowInt(
@@ -4679,6 +4737,7 @@ class ChatService {
       imageMessages: 0,
       videoMessages: 0,
       emojiMessages: 0,
+      fileMessages: 0,
       transferMessages: 0,
       redPacketMessages: 0,
       callMessages: 0
@@ -4700,6 +4759,7 @@ class ChatService {
     stats.imageMessages = Math.max(0, Math.floor(Number(data.image_messages || 0)))
     stats.videoMessages = Math.max(0, Math.floor(Number(data.video_messages || 0)))
     stats.emojiMessages = Math.max(0, Math.floor(Number(data.emoji_messages || 0)))
+    stats.fileMessages = Math.max(0, Math.floor(Number(data.file_messages || 0)))
     stats.callMessages = Math.max(0, Math.floor(Number(data.call_messages || 0)))
     stats.transferMessages = Math.max(0, Math.floor(Number(data.transfer_messages || 0)))
     stats.redPacketMessages = Math.max(0, Math.floor(Number(data.red_packet_messages || 0)))
@@ -4715,8 +4775,22 @@ class ChatService {
         stats.transferMessages = preciseCounters.transferMessages
         stats.redPacketMessages = preciseCounters.redPacketMessages
         stats.callMessages = preciseCounters.callMessages
+        stats.fileMessages = preciseCounters.fileMessages
       } catch {
         // 保留 native 聚合结果作为兜底
+      }
+    } else {
+      // Native 聚合可能不识别 25769803825 等文件消息变体，返回 0 但 key 存在。
+      // 当 Native 返回的文件消息数为 0 时，通过轻量 cursor 扫描补充，避免漏统计。
+      // 仅在 0 时兜底是为了兼顾性能：若 Native 已给出非 0 结果，通常已覆盖常见文件消息。
+      const nativeFileMessages = Math.max(0, Math.floor(Number(data.file_messages || 0)))
+      if (nativeFileMessages === 0) {
+        try {
+          const cursorFileMessages = await this.collectFileMessageCountByCursorScan(sessionId, beginTimestamp, endTimestamp)
+          stats.fileMessages = Math.max(nativeFileMessages, cursorFileMessages)
+        } catch {
+          // 保留 native 聚合结果作为兜底
+        }
       }
     }
 
@@ -4742,6 +4816,7 @@ class ChatService {
       imageMessages: Math.max(0, Math.floor(Number(row?.image_messages || 0))),
       videoMessages: Math.max(0, Math.floor(Number(row?.video_messages || 0))),
       emojiMessages: Math.max(0, Math.floor(Number(row?.emoji_messages || 0))),
+      fileMessages: Math.max(0, Math.floor(Number(row?.file_messages || 0))),
       callMessages: Math.max(0, Math.floor(Number(row?.call_messages || 0))),
       transferMessages: Math.max(0, Math.floor(Number(row?.transfer_messages || 0))),
       redPacketMessages: Math.max(0, Math.floor(Number(row?.red_packet_messages || 0)))
@@ -4864,6 +4939,7 @@ class ChatService {
       imageMessages: 0,
       videoMessages: 0,
       emojiMessages: 0,
+      fileMessages: 0,
       transferMessages: 0,
       redPacketMessages: 0,
       callMessages: 0
@@ -5021,7 +5097,8 @@ class ChatService {
 
     await this.forEachWithConcurrency(normalizedSessionIds, 3, async (sessionId) => {
       try {
-        const stats = hasNativeBatchStats && nativeBatchStats[sessionId]
+        const fromNativeBatch = hasNativeBatchStats && nativeBatchStats[sessionId]
+        const stats = fromNativeBatch
           ? { ...nativeBatchStats[sessionId] }
           : await this.collectSessionExportStats(
             sessionId,
@@ -5030,6 +5107,16 @@ class ChatService {
             beginTimestamp,
             endTimestamp
           )
+        // Native 批量统计可能不识别文件消息变体（如 25769803825），对 fileMessages 为 0 的会话补充 cursor 扫描。
+        // 导出页同时加载多个会话时走批量路径，这里需要与单会话路径保持一致的兜底策略。
+        if (fromNativeBatch && stats.fileMessages === 0) {
+          try {
+            const cursorFileMessages = await this.collectFileMessageCountByCursorScan(sessionId, beginTimestamp, endTimestamp)
+            stats.fileMessages = Math.max(stats.fileMessages, cursorFileMessages)
+          } catch {
+            // 保留 native 批量结果作为兜底
+          }
+        }
         if (sessionId.endsWith('@chatroom')) {
           if (shouldLoadGroupMemberCount) {
             stats.groupMemberCount = typeof memberCountMap[sessionId] === 'number'

--- a/electron/services/sessionStatsCacheService.ts
+++ b/electron/services/sessionStatsCacheService.ts
@@ -2,7 +2,8 @@ import { join, dirname } from 'path'
 import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'fs'
 import { ConfigService } from './config'
 
-const CACHE_VERSION = 2
+/** 缓存版本号。增加/修改 SessionStatsCacheStats 字段后必须提升，避免旧缓存被误用。 */
+const CACHE_VERSION = 4
 const MAX_SESSION_ENTRIES_PER_SCOPE = 2000
 const MAX_SCOPE_ENTRIES = 12
 
@@ -12,6 +13,8 @@ export interface SessionStatsCacheStats {
   imageMessages: number
   videoMessages: number
   emojiMessages: number
+  /** 文件类消息数量（对应 ExportSessionStats.fileMessages） */
+  fileMessages: number
   transferMessages: number
   redPacketMessages: number
   callMessages: number
@@ -53,6 +56,7 @@ function normalizeStats(raw: unknown): SessionStatsCacheStats | null {
   const imageMessages = toNonNegativeInt(source.imageMessages)
   const videoMessages = toNonNegativeInt(source.videoMessages)
   const emojiMessages = toNonNegativeInt(source.emojiMessages)
+  const fileMessages = toNonNegativeInt(source.fileMessages)
   const transferMessages = toNonNegativeInt(source.transferMessages)
   const redPacketMessages = toNonNegativeInt(source.redPacketMessages)
   const callMessages = toNonNegativeInt(source.callMessages)
@@ -63,6 +67,7 @@ function normalizeStats(raw: unknown): SessionStatsCacheStats | null {
     imageMessages === undefined ||
     videoMessages === undefined ||
     emojiMessages === undefined ||
+    fileMessages === undefined ||
     transferMessages === undefined ||
     redPacketMessages === undefined ||
     callMessages === undefined
@@ -76,6 +81,7 @@ function normalizeStats(raw: unknown): SessionStatsCacheStats | null {
     imageMessages,
     videoMessages,
     emojiMessages,
+    fileMessages,
     transferMessages,
     redPacketMessages,
     callMessages

--- a/electron/services/sessionStatsCacheService.ts
+++ b/electron/services/sessionStatsCacheService.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'fs'
 import { ConfigService } from './config'
 
 /** 缓存版本号。增加/修改 SessionStatsCacheStats 字段后必须提升，避免旧缓存被误用。 */
-const CACHE_VERSION = 4
+const CACHE_VERSION = 3
 const MAX_SESSION_ENTRIES_PER_SCOPE = 2000
 const MAX_SCOPE_ENTRIES = 12
 

--- a/src/pages/Export/ExportPage.tsx
+++ b/src/pages/Export/ExportPage.tsx
@@ -60,7 +60,7 @@ function ExportPage() {
   } = useContactsLoader()
 
   // ── 3. Metrics ──
-  const { metricsMap, fetchMetrics } = useSessionMetrics()
+  const { metricsMap, fetchMetrics, loadingRefs } = useSessionMetrics()
 
   const {
     filteredSessions,
@@ -212,6 +212,7 @@ function ExportPage() {
             sortConfig={sortConfig}
             onSortChange={setSortConfig}
             metricsMap={metricsMap}
+            loadingRefs={loadingRefs}
             onSingleExport={handleSingleExport}
             onBatchExport={handleExportSelected}
             onAutomationExport={handleAutomationExportFromSelection}

--- a/src/pages/Export/components/SessionTable/SessionTable.scss
+++ b/src/pages/Export/components/SessionTable/SessionTable.scss
@@ -288,3 +288,144 @@
     }
   }
 }
+
+// ── Skeleton Loading (参考「我的足迹」的 skeleton-shimmer 风格) ─────────
+.st-skeleton-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding: 0 24px;
+
+  .st-skeleton-header {
+    display: grid;
+    grid-template-columns: 48px minmax(200px, 1fr) 80px 120px 60px 60px 60px 60px 60px 80px;
+    align-items: center;
+    gap: 8px;
+    height: 44px;
+    border-bottom: 1px solid color-mix(in srgb, var(--border-color) 40%, transparent);
+
+    .st-skeleton-cell {
+      height: 14px;
+      border-radius: 4px;
+
+      &:nth-child(3),
+      &:nth-child(4),
+      &:nth-child(5),
+      &:nth-child(6),
+      &:nth-child(7),
+      &:nth-child(8),
+      &:nth-child(9) {
+        margin-left: auto;
+        width: 60%;
+      }
+
+      &:last-child {
+        margin: 0 auto;
+        width: 50%;
+      }
+    }
+  }
+
+  .st-skeleton-rows {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+
+    .st-skeleton-row {
+      display: grid;
+      grid-template-columns: 48px minmax(200px, 1fr) 80px 120px 60px 60px 60px 60px 60px 80px;
+      align-items: center;
+      gap: 8px;
+      height: 64px;
+      border-bottom: 1px solid color-mix(in srgb, var(--border-color) 20%, transparent);
+      padding: 0;
+
+      .st-skeleton-checkbox {
+        width: 18px;
+        height: 18px;
+        border-radius: 4px;
+      }
+
+      .st-skeleton-info {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+
+        .st-skeleton-avatar {
+          width: 40px;
+          height: 40px;
+          border-radius: 8px;
+          flex-shrink: 0;
+        }
+
+        .st-skeleton-text {
+          display: flex;
+          flex-direction: column;
+          gap: 6px;
+          flex: 1;
+          overflow: hidden;
+
+          .st-skeleton-line {
+            height: 14px;
+            border-radius: 4px;
+            width: 60%;
+
+            &.short {
+              width: 40%;
+            }
+          }
+        }
+      }
+
+      .st-skeleton-stat {
+        height: 14px;
+        border-radius: 4px;
+        width: 60%;
+        margin-left: auto;
+      }
+    }
+  }
+}
+
+.st-skeleton-shimmer {
+  position: relative;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--text-tertiary) 6%, transparent);
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      color-mix(in srgb, var(--bg-primary) 50%, transparent),
+      transparent
+    );
+    transform: translateX(-100%);
+    animation: stShimmer 1.5s infinite;
+  }
+}
+
+@keyframes stShimmer {
+  100% { transform: translateX(100%); }
+}
+
+// 行级统计 shimmer 占位与数字淡入
+.st-stat-shimmer {
+  display: inline-block;
+  width: 20px;
+  height: 10px;
+  border-radius: 4px;
+  @extend .st-skeleton-shimmer;
+}
+
+.st-stat-fade-in {
+  animation: stStatFadeIn 0.2s ease forwards;
+}
+
+@keyframes stStatFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}

--- a/src/pages/Export/components/SessionTable/index.tsx
+++ b/src/pages/Export/components/SessionTable/index.tsx
@@ -23,6 +23,7 @@ interface SessionTableProps {
   onAutomationExport?: () => void
   isLoading?: boolean
   metricsMap?: Record<string, SessionContentMetric>
+  loadingRefs?: Set<string>
 }
 
 const SessionTable: React.FC<SessionTableProps> = ({
@@ -39,7 +40,8 @@ const SessionTable: React.FC<SessionTableProps> = ({
   onBatchExport,
   onAutomationExport,
   isLoading,
-  metricsMap
+  metricsMap,
+  loadingRefs
 }) => {
   const virtuosoRef = useRef<VirtuosoHandle>(null)
 
@@ -160,9 +162,35 @@ const SessionTable: React.FC<SessionTableProps> = ({
 
       {/* ─── Virtualized List ─────────────────────────────────────────── */}
       <div className="table-body">
-        {sessions.length === 0 ? (
+        {isLoading && sessions.length === 0 ? (
+          // 初始加载骨架屏，风格与「我的足迹」保持一致
+          <div className="st-skeleton-body" aria-busy="true" aria-live="polite">
+            <div className="st-skeleton-header">
+              {Array.from({ length: 10 }).map((_, i) => (
+                <div key={i} className="st-skeleton-cell st-skeleton-shimmer" />
+              ))}
+            </div>
+            <div className="st-skeleton-rows">
+              {Array.from({ length: 10 }).map((_, rowIndex) => (
+                <div key={rowIndex} className="st-skeleton-row">
+                  <div className="st-skeleton-checkbox st-skeleton-shimmer" />
+                  <div className="st-skeleton-info">
+                    <div className="st-skeleton-avatar st-skeleton-shimmer" />
+                    <div className="st-skeleton-text">
+                      <div className="st-skeleton-line st-skeleton-shimmer" />
+                      <div className="st-skeleton-line short st-skeleton-shimmer" />
+                    </div>
+                  </div>
+                  {Array.from({ length: 7 }).map((_, i) => (
+                    <div key={i} className="st-skeleton-stat st-skeleton-shimmer" />
+                  ))}
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : sessions.length === 0 ? (
           <div className="empty-state">
-            {isLoading ? '加载中...' : (searchQuery ? '没有匹配的会话' : '此分类下没有会话')}
+            {searchQuery ? '没有匹配的会话' : '此分类下没有会话'}
           </div>
         ) : (
           <Virtuoso
@@ -170,8 +198,9 @@ const SessionTable: React.FC<SessionTableProps> = ({
             data={sessions}
             itemContent={(index, session) => {
               if (!session) return null
-              
+
               const metrics = metricsMap?.[session.username]
+              const isMetricsLoading = !metrics && loadingRefs?.has(session.username)
               const totalCount = metrics?.totalMessages ?? session.messageCountHint ?? 0
 
               return (
@@ -198,17 +227,53 @@ const SessionTable: React.FC<SessionTableProps> = ({
                       <span className="st-id" title={session.username}>{session.username}</span>
                     </div>
                   </div>
-                  <div className="col-count">{totalCount.toLocaleString()}</div>
+                  <div className="col-count">
+                    {isMetricsLoading ? (
+                      <span className="st-stat-shimmer" />
+                    ) : (
+                      <span className="st-stat-fade-in">{totalCount.toLocaleString()}</span>
+                    )}
+                  </div>
                   <div className="col-time">
                     {session.lastTimestamp ? formatLatestMessageTimeFromSeconds(session.lastTimestamp).text : '-'}
                   </div>
-                  <div className="col-stat">{metrics?.emojiMessages ?? '-'}</div>
-                  <div className="col-stat">{metrics?.voiceMessages ?? '-'}</div>
-                  <div className="col-stat">{metrics?.imageMessages ?? '-'}</div>
-                  <div className="col-stat">{metrics?.videoMessages ?? '-'}</div>
-                  <div className="col-stat">{metrics?.fileMessages ?? '-'}</div>
+                  <div className="col-stat">
+                    {isMetricsLoading ? (
+                      <span className="st-stat-shimmer" />
+                    ) : (
+                      <span className="st-stat-fade-in">{metrics?.emojiMessages ?? '-'}</span>
+                    )}
+                  </div>
+                  <div className="col-stat">
+                    {isMetricsLoading ? (
+                      <span className="st-stat-shimmer" />
+                    ) : (
+                      <span className="st-stat-fade-in">{metrics?.voiceMessages ?? '-'}</span>
+                    )}
+                  </div>
+                  <div className="col-stat">
+                    {isMetricsLoading ? (
+                      <span className="st-stat-shimmer" />
+                    ) : (
+                      <span className="st-stat-fade-in">{metrics?.imageMessages ?? '-'}</span>
+                    )}
+                  </div>
+                  <div className="col-stat">
+                    {isMetricsLoading ? (
+                      <span className="st-stat-shimmer" />
+                    ) : (
+                      <span className="st-stat-fade-in">{metrics?.videoMessages ?? '-'}</span>
+                    )}
+                  </div>
+                  <div className="col-stat">
+                    {isMetricsLoading ? (
+                      <span className="st-stat-shimmer" />
+                    ) : (
+                      <span className="st-stat-fade-in">{metrics?.fileMessages ?? '-'}</span>
+                    )}
+                  </div>
                   <div className="col-action">
-                    <button 
+                    <button
                       className="st-action-btn"
                       onClick={(e) => {
                         e.stopPropagation()

--- a/src/pages/Export/hooks/useSessionMetrics.ts
+++ b/src/pages/Export/hooks/useSessionMetrics.ts
@@ -56,7 +56,7 @@ export const useSessionMetrics = create<SessionMetricsState>((set, get) => ({
             imageMessages: sessionStat.imageMessages, 
             videoMessages: sessionStat.videoMessages,
             emojiMessages: sessionStat.emojiMessages,
-            fileMessages: 0 // Will need specific metric if available
+            fileMessages: sessionStat.fileMessages ?? 0  // 文件消息数量，由后端 ExportSessionStats 返回
           }
         }
       }

--- a/src/pages/Export/hooks/useSessionMetrics.ts
+++ b/src/pages/Export/hooks/useSessionMetrics.ts
@@ -18,6 +18,16 @@ export interface SessionContentMetric {
   appMessages?: number
 }
 
+const METRICS_CHUNK_SIZE = 40
+
+function chunkArray<T>(arr: T[], size: number): T[][] {
+  const chunks: T[][] = []
+  for (let i = 0; i < arr.length; i += size) {
+    chunks.push(arr.slice(i, i + size))
+  }
+  return chunks
+}
+
 interface SessionMetricsState {
   metricsMap: Record<string, SessionContentMetric>
   isLoading: boolean
@@ -39,31 +49,35 @@ export const useSessionMetrics = create<SessionMetricsState>((set, get) => ({
     if (missingIds.length === 0) return
 
     set({ isLoading: true, error: null })
-    
+
     const newLoadingRefs = new Set(loadingRefs)
     missingIds.forEach(id => newLoadingRefs.add(id))
     set({ loadingRefs: newLoadingRefs })
 
     try {
-      const stats = await window.electronAPI.chat.getExportSessionStats(missingIds, { includeRelations: false })
-      
-      const newMetrics: Record<string, SessionContentMetric> = {}
-      if (stats.success && stats.data) {
-        for (const [sessionId, sessionStat] of Object.entries(stats.data)) {
-          newMetrics[sessionId] = {
-            totalMessages: sessionStat.totalMessages,
-            voiceMessages: sessionStat.voiceMessages,
-            imageMessages: sessionStat.imageMessages, 
-            videoMessages: sessionStat.videoMessages,
-            emojiMessages: sessionStat.emojiMessages,
-            fileMessages: sessionStat.fileMessages ?? 0  // 文件消息数量，由后端 ExportSessionStats 返回
+      // 将会话分批顺序请求，每批返回后立即更新 UI，实现「扫出一个放一个」的渐进式效果。
+      const chunks = chunkArray(missingIds, METRICS_CHUNK_SIZE)
+      for (const chunk of chunks) {
+        const stats = await window.electronAPI.chat.getExportSessionStats(chunk, { includeRelations: false })
+
+        const newMetrics: Record<string, SessionContentMetric> = {}
+        if (stats.success && stats.data) {
+          for (const [sessionId, sessionStat] of Object.entries(stats.data)) {
+            newMetrics[sessionId] = {
+              totalMessages: sessionStat.totalMessages,
+              voiceMessages: sessionStat.voiceMessages,
+              imageMessages: sessionStat.imageMessages,
+              videoMessages: sessionStat.videoMessages,
+              emojiMessages: sessionStat.emojiMessages,
+              fileMessages: sessionStat.fileMessages ?? 0  // 文件消息数量，由后端 ExportSessionStats 返回
+            }
           }
         }
-      }
 
-      set(state => ({ 
-        metricsMap: { ...state.metricsMap, ...newMetrics }
-      }))
+        set(state => ({
+          metricsMap: { ...state.metricsMap, ...newMetrics }
+        }))
+      }
     } catch (err) {
       console.error('Failed to fetch session metrics:', err)
       set({ error: err instanceof Error ? err : new Error(String(err)) })

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -931,6 +931,8 @@ export interface ExportSessionContentMetricCacheEntry {
   imageMessages?: number
   videoMessages?: number
   emojiMessages?: number
+  /** 文件类消息数量，与后端 ExportSessionStats.fileMessages 对齐 */
+  fileMessages?: number
   firstTimestamp?: number
   lastTimestamp?: number
 }
@@ -1099,6 +1101,9 @@ export async function getExportSessionContentMetricCache(scopeKey: string): Prom
     if (typeof source.emojiMessages === 'number' && Number.isFinite(source.emojiMessages) && source.emojiMessages >= 0) {
       metric.emojiMessages = Math.floor(source.emojiMessages)
     }
+    if (typeof source.fileMessages === 'number' && Number.isFinite(source.fileMessages) && source.fileMessages >= 0) {
+      metric.fileMessages = Math.floor(source.fileMessages)
+    }
     if (typeof source.firstTimestamp === 'number' && Number.isFinite(source.firstTimestamp) && source.firstTimestamp > 0) {
       metric.firstTimestamp = Math.floor(source.firstTimestamp)
     }
@@ -1143,6 +1148,9 @@ export async function setExportSessionContentMetricCache(
     }
     if (typeof rawMetric.emojiMessages === 'number' && Number.isFinite(rawMetric.emojiMessages) && rawMetric.emojiMessages >= 0) {
       metric.emojiMessages = Math.floor(rawMetric.emojiMessages)
+    }
+    if (typeof rawMetric.fileMessages === 'number' && Number.isFinite(rawMetric.fileMessages) && rawMetric.fileMessages >= 0) {
+      metric.fileMessages = Math.floor(rawMetric.fileMessages)
     }
     if (typeof rawMetric.firstTimestamp === 'number' && Number.isFinite(rawMetric.firstTimestamp) && rawMetric.firstTimestamp > 0) {
       metric.firstTimestamp = Math.floor(rawMetric.firstTimestamp)

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -644,6 +644,8 @@ export interface ElectronAPI {
         imageMessages: number
         videoMessages: number
         emojiMessages: number
+        /** 文件类消息数量 */
+        fileMessages: number
         transferMessages: number
         redPacketMessages: number
         callMessages: number


### PR DESCRIPTION
fix(export): 修复导出页面文件消息数量始终显示为0

Native 聚合接口仅统计 localType === 49 的文件消息，但微信 4.x
还 34359738417 / 103079215153 / 25769803825 等文件消息变体，
导致 Native 返回 file_messages: 0 且 key 存在，光标兜底逻辑
无法触发。

本次修改：

在 ExportSessionStats 中增加 fileMessages 字段
新增collectFileMessageCountByCursorScan覆盖所有文件变体
单会话和批量路径均在本机返回0时补充光标扫描
同步更新前转发服务器结构与IPC类型定义
提升会话统计服务器版本号，避免恢复数据库错误
修复：导出页「文件」列数量识别为 0

另外我注意到VScode报错文件chatService.ts中存在类型错误，isPackages、resourcesPath、appPath但是封装和测试的时候并没有出现报错，可能是VScode的错报，我的代码能力比较弱，辛苦大佬看下。