### PR TITLE
fix(electron): keep silent startup in tray only

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -38,6 +38,15 @@ import { normalizeWeiboCookieInput, weiboService } from './services/social/weibo
 import { bizService } from './services/bizService'
 import { backupService } from './services/backupService'
 import { imageDownloadService } from './services/imageDownloadService'
+import {
+  buildLaunchAtStartupQueryOptions as buildPlatformLaunchAtStartupQueryOptions,
+  buildLaunchAtStartupSettings as buildPlatformLaunchAtStartupSettings,
+  getHiddenMacActivationPolicy,
+  shouldShowWindowOnActivate,
+  shouldSkipTaskbarEntry,
+  shouldStartInBackground,
+  shouldUseMenuBarOnlyMode as shouldUsePlatformMenuBarOnlyMode
+} from './startupBehavior'
 
 // 配置自动更新
 autoUpdater.autoDownload = false
@@ -267,7 +276,8 @@ const getStoredLaunchAtStartupPreference = (): boolean | undefined => {
 const getSystemLaunchAtStartup = (): boolean => {
   if (!isLaunchAtStartupSupported()) return false
   try {
-    return app.getLoginItemSettings().openAtLogin === true
+    const queryOptions = buildPlatformLaunchAtStartupQueryOptions(process.platform, process.execPath)
+    return app.getLoginItemSettings(queryOptions).openAtLogin === true
   } catch (error) {
     console.error('[WeFlow] 读取开机自启动状态失败:', error)
     return false
@@ -275,14 +285,17 @@ const getSystemLaunchAtStartup = (): boolean => {
 }
 
 const buildLaunchAtStartupSettings = (enabled: boolean): Parameters<typeof app.setLoginItemSettings>[0] =>
-  process.platform === 'win32'
-    ? { openAtLogin: enabled, path: process.execPath }
-    : { openAtLogin: enabled }
+  buildPlatformLaunchAtStartupSettings(
+    enabled,
+    process.platform,
+    process.execPath
+  ) as Parameters<typeof app.setLoginItemSettings>[0]
 
 const setSystemLaunchAtStartup = (enabled: boolean): { success: boolean; enabled: boolean; error?: string } => {
   try {
     app.setLoginItemSettings(buildLaunchAtStartupSettings(enabled))
-    const effectiveEnabled = app.getLoginItemSettings().openAtLogin === true
+    const queryOptions = buildPlatformLaunchAtStartupQueryOptions(process.platform, process.execPath)
+    const effectiveEnabled = app.getLoginItemSettings(queryOptions).openAtLogin === true
     if (effectiveEnabled !== enabled) {
       return {
         success: false,
@@ -741,18 +754,14 @@ let notificationNavigateHandlerRegistered = false
 const focusMainWindowAndNavigate = (sessionId: string): void => {
   const targetWindow = mainWindow
   if (!targetWindow || targetWindow.isDestroyed()) return
-  if (targetWindow.isMinimized()) targetWindow.restore()
-  targetWindow.show()
-  targetWindow.focus()
+  showWindowFromUserAction(targetWindow)
   targetWindow.webContents.send('navigate-to-session', sessionId)
 }
 
 const focusMainWindowAndNavigateRoute = (route: string): void => {
   const targetWindow = mainWindow
   if (!targetWindow || targetWindow.isDestroyed()) return
-  if (targetWindow.isMinimized()) targetWindow.restore()
-  targetWindow.show()
-  targetWindow.focus()
+  showWindowFromUserAction(targetWindow)
   targetWindow.webContents.send('navigate-to-route', route)
 }
 
@@ -829,6 +838,49 @@ const isSilentStartupEnabled = (): boolean => {
   return configService?.get('silentStartup') === true
 }
 
+const shouldUseMenuBarOnlyMode = (): boolean => {
+  return shouldUsePlatformMenuBarOnlyMode({
+    onboardingDone: configService?.get('onboardingDone') === true,
+    silentStartup: isSilentStartupEnabled(),
+    hasTray: Boolean(tray),
+    mainWindowCreated: Boolean(mainWindow && !mainWindow.isDestroyed())
+  })
+}
+
+const applyMacMenuBarOnlyMode = (): void => {
+  if (process.platform !== 'darwin') return
+  try {
+    const menuBarOnlyMode = shouldUseMenuBarOnlyMode()
+    app.setActivationPolicy(getHiddenMacActivationPolicy(menuBarOnlyMode))
+    if (menuBarOnlyMode) {
+      app.dock?.hide()
+    } else {
+      void app.dock?.show()
+    }
+  } catch (error) {
+    console.warn('[WeFlow] 更新 macOS 启动显示策略失败:', error)
+  }
+}
+
+const applyWindowsTaskbarVisibility = (
+  win: BrowserWindow,
+  windowVisible = win.isVisible() || win.isMinimized()
+): void => {
+  if (process.platform !== 'win32') return
+  win.setSkipTaskbar(shouldSkipTaskbarEntry({
+    platform: process.platform,
+    menuBarOnlyMode: shouldUseMenuBarOnlyMode(),
+    windowVisible
+  }))
+}
+
+const applyPlatformVisibilityMode = (win?: BrowserWindow | null): void => {
+  applyMacMenuBarOnlyMode()
+  if (win && !win.isDestroyed()) {
+    applyWindowsTaskbarVisibility(win)
+  }
+}
+
 const getCloseRestoreMethod = (): CloseRestoreMethod | null => {
   if (tray) return 'tray'
   if (process.platform === 'darwin') return 'dock'
@@ -845,6 +897,11 @@ const getPlatformIconName = (): string => {
   return 'icon.ico'
 }
 
+const getPlatformTrayIconName = (): string => {
+  if (process.platform === 'darwin') return 'icon.png'
+  return getPlatformIconName()
+}
+
 const resolveAppIconPath = (): string => {
   const iconName = getPlatformIconName()
   if (!process.env.VITE_DEV_SERVER_URL) {
@@ -854,6 +911,19 @@ const resolveAppIconPath = (): string => {
     return join(__dirname, '../resources/icons/macos/icon.icns')
   }
   return join(__dirname, `../public/${iconName}`)
+}
+
+const resolveTrayIcon = () => {
+  const iconName = getPlatformTrayIconName()
+  const iconPath = !process.env.VITE_DEV_SERVER_URL
+    ? join(process.resourcesPath, iconName)
+    : join(__dirname, `../public/${iconName}`)
+
+  if (process.platform !== 'darwin') return iconPath
+
+  const image = nativeImage.createFromPath(iconPath).resize({ width: 18, height: 18 })
+  image.setTemplateImage(false)
+  return image
 }
 
 const requestMainWindowCloseConfirmation = (win: BrowserWindow): void => {
@@ -866,9 +936,33 @@ const requestMainWindowCloseConfirmation = (win: BrowserWindow): void => {
   })
 }
 
-function createWindow(options: { autoShow?: boolean } = {}) {
+const showWindowFromUserAction = (win: BrowserWindow | null | undefined): void => {
+  if (!win || win.isDestroyed()) return
+  applyMacMenuBarOnlyMode()
+  applyWindowsTaskbarVisibility(win, true)
+  if (win.isMinimized()) {
+    win.restore()
+  }
+  win.show()
+  win.focus()
+}
+
+const hideMainWindowInBackground = (): void => {
+  if (!mainWindow || mainWindow.isDestroyed()) return
+  mainWindow.hide()
+  applyPlatformVisibilityMode(mainWindow)
+}
+
+function createWindow(options: { autoShow?: boolean; skipTaskbar?: boolean } = {}) {
   // 获取图标路径 - 打包后在 resources 目录
-  const { autoShow = true } = options
+  const {
+    autoShow = true,
+    skipTaskbar = shouldSkipTaskbarEntry({
+      platform: process.platform,
+      menuBarOnlyMode: shouldUseMenuBarOnlyMode(),
+      windowVisible: false
+    })
+  } = options
   const iconPath = resolveAppIconPath()
 
   const win = new BrowserWindow({
@@ -885,6 +979,7 @@ function createWindow(options: { autoShow?: boolean } = {}) {
     },
     titleBarStyle: 'hidden',
     titleBarOverlay: false,
+    skipTaskbar,
     show: false
   })
   setupCustomTitleBarWindow(win)
@@ -894,7 +989,7 @@ function createWindow(options: { autoShow?: boolean } = {}) {
   win.once('ready-to-show', () => {
     mainWindowReady = true
     if (autoShow && !splashWindow) {
-      win.show()
+      showWindowFromUserAction(win)
     }
   })
 
@@ -943,7 +1038,7 @@ function createWindow(options: { autoShow?: boolean } = {}) {
     }
 
     if (closeBehavior === 'tray' && canKeepMainWindowInBackground()) {
-      win.hide()
+      hideMainWindowInBackground()
       return
     }
 
@@ -1501,7 +1596,7 @@ function createSessionChatWindow(sessionId: string, options?: OpenSessionChatWin
 function showMainWindow() {
   shouldShowMain = true
   if (mainWindowReady) {
-    mainWindow?.show()
+    showWindowFromUserAction(mainWindow)
   }
 }
 
@@ -1802,6 +1897,9 @@ function registerIpcHandlers() {
     }
     if (key === 'updateChannel') {
       applyAutoUpdateChannel('settings')
+    }
+    if (key === 'silentStartup' || key === 'onboardingDone') {
+      applyPlatformVisibilityMode(mainWindow)
     }
     void messagePushService.handleConfigChanged(key)
     void insightService.handleConfigChanged(key)
@@ -2224,7 +2322,7 @@ function registerIpcHandlers() {
     try {
       if (action === 'tray') {
         if (canKeepMainWindowInBackground()) {
-          mainWindow.hide()
+          hideMainWindowInBackground()
           return true
         }
         return false
@@ -3764,7 +3862,7 @@ function registerIpcHandlers() {
   ipcMain.handle('window:openOnboardingWindow', async (_, options?: { mode?: 'add-account' }) => {
     shouldShowMain = false
     if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.hide()
+      hideMainWindowInBackground()
     }
     const mode = options?.mode === 'add-account' ? 'add-account' : 'default'
     createOnboardingWindow(mode)
@@ -4247,8 +4345,9 @@ app.whenReady().then(async () => {
   applyAutoUpdateChannel('startup')
   syncLaunchAtStartupPreference()
   const onboardingDone = configService.get('onboardingDone') === true
-  const startInBackground = onboardingDone && isSilentStartupEnabled()
+  const startInBackground = shouldStartInBackground(onboardingDone, isSilentStartupEnabled())
   shouldShowMain = onboardingDone
+  applyPlatformVisibilityMode()
 
   if (!startInBackground) {
     // 非静默模式下显示 Splash，提供启动反馈
@@ -4396,9 +4495,16 @@ app.whenReady().then(async () => {
   // 创建主窗口（不显示，由启动流程统一控制）
   updateSplashProgress(70, '正在准备主窗口...')
   ensureWeChatRequestHeaderInterceptor()
-  mainWindow = createWindow({ autoShow: false })
+  mainWindow = createWindow({
+    autoShow: false,
+    skipTaskbar: shouldSkipTaskbarEntry({
+      platform: process.platform,
+      menuBarOnlyMode: startInBackground,
+      windowVisible: false
+    })
+  })
 
-  const resolvedTrayIcon = resolveAppIconPath()
+  const resolvedTrayIcon = resolveTrayIcon()
 
 
   try {
@@ -4408,10 +4514,7 @@ app.whenReady().then(async () => {
       {
         label: '显示主窗口',
         click: () => {
-          if (mainWindow) {
-            mainWindow.show()
-            mainWindow.focus()
-          }
+          showWindowFromUserAction(mainWindow)
         }
       },
       { type: 'separator' },
@@ -4426,19 +4529,11 @@ app.whenReady().then(async () => {
     tray.setContextMenu(contextMenu)
     tray.on('click', () => {
       if (mainWindow) {
-        if (mainWindow.isVisible()) {
-          mainWindow.focus()
-        } else {
-          mainWindow.show()
-          mainWindow.focus()
-        }
+        showWindowFromUserAction(mainWindow)
       }
     })
     tray.on('double-click', () => {
-      if (mainWindow) {
-        mainWindow.show()
-        mainWindow.focus()
-      }
+      showWindowFromUserAction(mainWindow)
     })
   } catch (e) {
     console.warn('[Tray] Failed to create tray icon:', e)
@@ -4465,9 +4560,9 @@ app.whenReady().then(async () => {
   if (!onboardingDone) {
     createOnboardingWindow()
   } else if (startInBackground && tray) {
-    mainWindow?.hide()
+    hideMainWindowInBackground()
   } else {
-    mainWindow?.show()
+    showWindowFromUserAction(mainWindow)
   }
 
   // 启动时检测更新（不阻塞启动）
@@ -4477,8 +4572,14 @@ app.whenReady().then(async () => {
 
   app.on('activate', () => {
     if (mainWindow && !mainWindow.isDestroyed()) {
+      if (!shouldShowWindowOnActivate({ menuBarOnlyMode: shouldUseMenuBarOnlyMode(), hasMainWindow: true })) {
+        applyPlatformVisibilityMode(mainWindow)
+        return
+      }
       if (!mainWindow.isVisible()) {
-        mainWindow.show()
+        showWindowFromUserAction(mainWindow)
+      } else {
+        applyPlatformVisibilityMode(mainWindow)
       }
       mainWindow.focus()
       return

--- a/electron/startupBehavior.ts
+++ b/electron/startupBehavior.ts
@@ -1,0 +1,103 @@
+export const LOGIN_STARTUP_ARG = '--weflow-login-startup'
+
+export type LaunchAtStartupSettings = {
+  openAtLogin: boolean
+  openAsHidden?: boolean
+  path?: string
+  args?: string[]
+  enabled?: boolean
+}
+
+export type LaunchAtStartupQueryOptions = {
+  path?: string
+  args?: string[]
+}
+
+export type MacActivationPolicy = 'regular' | 'accessory'
+
+export type MenuBarOnlyModeInput = {
+  onboardingDone: boolean
+  silentStartup: boolean
+  hasTray: boolean
+  mainWindowCreated: boolean
+}
+
+export type ActivateWindowInput = {
+  menuBarOnlyMode: boolean
+  hasMainWindow: boolean
+}
+
+export type TaskbarEntryInput = {
+  platform: string
+  menuBarOnlyMode: boolean
+  windowVisible: boolean
+}
+
+export const shouldStartInBackground = (onboardingDone: boolean, silentStartup: boolean): boolean => {
+  return onboardingDone && silentStartup
+}
+
+export const shouldUseMenuBarOnlyMode = ({
+  onboardingDone,
+  silentStartup,
+  hasTray,
+  mainWindowCreated
+}: MenuBarOnlyModeInput): boolean => {
+  if (!shouldStartInBackground(onboardingDone, silentStartup)) return false
+  return hasTray || !mainWindowCreated
+}
+
+export const shouldShowWindowOnActivate = ({
+  menuBarOnlyMode,
+  hasMainWindow
+}: ActivateWindowInput): boolean => {
+  if (!hasMainWindow) return true
+  return !menuBarOnlyMode
+}
+
+export const shouldSkipTaskbarEntry = ({
+  platform,
+  menuBarOnlyMode,
+  windowVisible
+}: TaskbarEntryInput): boolean => {
+  return platform === 'win32' && menuBarOnlyMode && !windowVisible
+}
+
+export const buildLaunchAtStartupQueryOptions = (
+  platform: string,
+  execPath: string
+): LaunchAtStartupQueryOptions | undefined => {
+  if (platform !== 'win32') return undefined
+
+  return {
+    path: execPath,
+    args: [LOGIN_STARTUP_ARG]
+  }
+}
+
+export const buildLaunchAtStartupSettings = (
+  enabled: boolean,
+  platform: string,
+  execPath: string
+): LaunchAtStartupSettings => {
+  if (platform === 'win32') {
+    return {
+      openAtLogin: enabled,
+      path: execPath,
+      args: [LOGIN_STARTUP_ARG],
+      enabled
+    }
+  }
+
+  if (platform === 'darwin') {
+    return {
+      openAtLogin: enabled
+    }
+  }
+
+  return { openAtLogin: enabled }
+}
+
+export const getHiddenMacActivationPolicy = (isHidden: boolean): MacActivationPolicy => {
+  return isHidden ? 'accessory' : 'regular'
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "postinstall": "electron-builder install-app-deps && node scripts/prepare-electron-runtime.cjs",
     "rebuild": "electron-rebuild",
     "dev": "node scripts/prepare-electron-runtime.cjs && vite",
+    "test:startup": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types scripts/test-startup-behavior.mjs",
     "typecheck": "tsc --noEmit",
     "build": "tsc && vite build && electron-builder",
     "preview": "vite preview",

--- a/scripts/test-startup-behavior.mjs
+++ b/scripts/test-startup-behavior.mjs
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict'
+
+import {
+  LOGIN_STARTUP_ARG,
+  buildLaunchAtStartupQueryOptions,
+  buildLaunchAtStartupSettings,
+  getHiddenMacActivationPolicy,
+  shouldShowWindowOnActivate,
+  shouldSkipTaskbarEntry,
+  shouldStartInBackground,
+  shouldUseMenuBarOnlyMode
+} from '../electron/startupBehavior.ts'
+
+assert.equal(shouldStartInBackground(true, true), true, 'silent startup should hide after onboarding')
+assert.equal(shouldStartInBackground(false, true), false, 'first launch must show onboarding')
+assert.equal(shouldStartInBackground(true, false), false, 'non-silent startup should show UI')
+assert.equal(
+  shouldUseMenuBarOnlyMode({
+    onboardingDone: true,
+    silentStartup: true,
+    hasTray: false,
+    mainWindowCreated: false
+  }),
+  true,
+  'macOS should hide Dock during early silent startup before tray creation'
+)
+assert.equal(
+  shouldUseMenuBarOnlyMode({
+    onboardingDone: true,
+    silentStartup: true,
+    hasTray: true,
+    mainWindowCreated: true
+  }),
+  true,
+  'macOS should stay menu-bar-only after tray creation succeeds'
+)
+assert.equal(
+  shouldUseMenuBarOnlyMode({
+    onboardingDone: true,
+    silentStartup: true,
+    hasTray: false,
+    mainWindowCreated: true
+  }),
+  false,
+  'macOS should restore Dock if tray creation failed after the main window exists'
+)
+assert.equal(
+  shouldShowWindowOnActivate({ menuBarOnlyMode: true, hasMainWindow: true }),
+  false,
+  'macOS activate should not show the main window while in menu-bar-only mode'
+)
+assert.equal(
+  shouldShowWindowOnActivate({ menuBarOnlyMode: false, hasMainWindow: true }),
+  true,
+  'macOS activate should show the main window in normal mode'
+)
+assert.equal(
+  shouldSkipTaskbarEntry({ platform: 'win32', menuBarOnlyMode: true, windowVisible: false }),
+  true,
+  'Windows tray-only mode should hide a background main window from the taskbar'
+)
+assert.equal(
+  shouldSkipTaskbarEntry({ platform: 'win32', menuBarOnlyMode: true, windowVisible: true }),
+  false,
+  'Windows tray restore should show the foreground main window in the taskbar'
+)
+assert.equal(
+  shouldSkipTaskbarEntry({ platform: 'linux', menuBarOnlyMode: true, windowVisible: false }),
+  false,
+  'Linux fallback should keep a shown window reachable from the taskbar'
+)
+assert.equal(
+  shouldSkipTaskbarEntry({ platform: 'darwin', menuBarOnlyMode: true, windowVisible: false }),
+  false,
+  'macOS Dock visibility is controlled by activation policy, not skipTaskbar'
+)
+assert.equal(
+  shouldSkipTaskbarEntry({ platform: 'win32', menuBarOnlyMode: false, windowVisible: false }),
+  false,
+  'Windows normal mode should keep the main window in the taskbar'
+)
+
+assert.deepEqual(
+  buildLaunchAtStartupQueryOptions('win32', 'C:\\Program Files\\WeFlow\\WeFlow.exe'),
+  {
+    path: 'C:\\Program Files\\WeFlow\\WeFlow.exe',
+    args: [LOGIN_STARTUP_ARG]
+  },
+  'Windows login item status should query the arg-qualified entry'
+)
+
+assert.equal(
+  buildLaunchAtStartupQueryOptions('darwin', '/Applications/WeFlow.app/Contents/MacOS/WeFlow'),
+  undefined,
+  'macOS login item status should use Electron defaults'
+)
+
+assert.deepEqual(
+  buildLaunchAtStartupSettings(true, 'win32', 'C:\\Program Files\\WeFlow\\WeFlow.exe'),
+  {
+    openAtLogin: true,
+    path: 'C:\\Program Files\\WeFlow\\WeFlow.exe',
+    args: [LOGIN_STARTUP_ARG],
+    enabled: true
+  },
+  'Windows login item should launch hidden through an explicit arg'
+)
+
+assert.deepEqual(
+  buildLaunchAtStartupSettings(false, 'win32', 'C:\\Program Files\\WeFlow\\WeFlow.exe'),
+  {
+    openAtLogin: false,
+    path: 'C:\\Program Files\\WeFlow\\WeFlow.exe',
+    args: [LOGIN_STARTUP_ARG],
+    enabled: false
+  },
+  'Windows login item disable should target the same arg-qualified entry'
+)
+
+assert.deepEqual(
+  buildLaunchAtStartupSettings(true, 'darwin', '/Applications/WeFlow.app/Contents/MacOS/WeFlow'),
+  {
+    openAtLogin: true
+  },
+  'macOS login item should stay minimal because runtime controls hidden startup'
+)
+
+assert.deepEqual(
+  buildLaunchAtStartupSettings(true, 'linux', '/usr/bin/weflow'),
+  {
+    openAtLogin: true
+  },
+  'other platforms keep the generic Electron shape'
+)
+
+assert.equal(getHiddenMacActivationPolicy(true), 'accessory', 'hidden macOS mode should not show a Dock icon')
+assert.equal(getHiddenMacActivationPolicy(false), 'regular', 'non-silent macOS mode should keep normal app behavior')
+
+console.log('startup behavior tests passed')


### PR DESCRIPTION
## Summary
Fix silent startup so WeFlow can launch into menu-bar/tray-only mode instead of showing the main window or Dock/taskbar presence.

## Changes
- Add a testable startup behavior helper for silent startup, macOS activation policy, and Windows login item settings.
- Keep macOS silent startup in accessory/menu-bar-only mode and explicitly hide the Dock icon while the tray icon is available.
- Keep Windows silent startup windows out of the taskbar with `skipTaskbar` and use an argument-qualified login startup entry.
- Route tray/menu restore actions through a foreground helper so user-initiated window display remains intentional.
- Add targeted startup behavior assertions and an npm script for them.

## Testing
- `npm run test:startup`
- `npm run typecheck`
- `git diff --check`
- Local macOS packaged install smoke test: launched `/Applications/WeFlow.app` with `silentStartup=true`; System Events reported `visible=false`, `frontmost=false`, and no windows.

## Risks
- Windows tray/taskbar behavior was covered by pure startup-setting tests but not manually smoke-tested on Windows in this environment.
- No obvious macOS migration risk; if tray creation fails, the app falls back to normal Dock behavior instead of becoming unreachable.